### PR TITLE
Cache results of `getTimezoneNameNoLocationSpecific`

### DIFF
--- a/code/Calendar.php
+++ b/code/Calendar.php
@@ -14,6 +14,9 @@ namespace Punic;
  */
 class Calendar
 {
+    /** @var array */
+    protected static $timezoneCache;
+
     /**
      * Convert a date/time representation to a {@link http://php.net/manual/class.datetime.php \DateTime} instance.
      * @param number|\DateTime|string $value An Unix timestamp, a `\DateTime` instance \DateTime or a string accepted by {@link http://php.net/manual/function.strtotime.php strtotime}.
@@ -402,6 +405,11 @@ class Calendar
      */
     public static function getTimezoneNameNoLocationSpecific($value, $width = 'long', $kind = '', $locale = '')
     {
+        $cacheKey = json_encode(array($value, $width, $kind, $locale));
+        if(isset(self::$timezoneCache[$cacheKey])) {
+            return self::$timezoneCache[$cacheKey];
+        }
+
         $result = '';
         if (!empty($value)) {
             $receivedPhpName = '';
@@ -501,6 +509,8 @@ class Calendar
                 }
             }
         }
+
+        self::$timezoneCache[$cacheKey] = $result;
 
         return $result;
     }


### PR DESCRIPTION
`getTimezoneNameNoLocationSpecific` is a very expensive operation and previously a simple looped time conversion (1000x) required more than two seconds to execute.

At ownCloud we use such date conversion actions pretty often and repeatedly and thus listing a folder with more than 20k files took more than 3 seconds longer just due to this single method.

A simple test script looping 10000 times shows the following performance gains:

![screen shot 2015-01-17 at 23 08 15](https://cloud.githubusercontent.com/assets/878997/5790550/c3e3a176-9e9d-11e4-8b47-5a3c3014cde3.png)

(wasn't able to get the unit tests locally running – should pass on Travis though)

Ref https://github.com/owncloud/core/issues/13434