### PR TITLE
php-cs-fixer

### DIFF
--- a/code/Calendar.php
+++ b/code/Calendar.php
@@ -19,30 +19,30 @@ class Calendar
 
     /**
      * Convert a date/time representation to a {@link http://php.net/manual/class.datetime.php \DateTime} instance.
-     * @param number|\DateTime|string $value An Unix timestamp, a `\DateTime` instance \DateTime or a string accepted by {@link http://php.net/manual/function.strtotime.php strtotime}.
-     * @param string|\DateTimeZone $toTimezone='' The timezone to set; leave empty to use the value of $fromTimezone (if it's empty we'll use the default timezone or the timezone associated to $value if it's already a `\DateTime`).
-     * @param string|\DateTimeZone $fromTimezone='' The original timezone of $value; leave empty to use the default timezone (or the timezone associated to $value if it's already a `\DateTime`).
-     * @return \DateTime|null Returns null if $value is empty, a `\DateTime` instance otherwise.
+     * @param  number|\DateTime|string          $value           An Unix timestamp, a `\DateTime` instance \DateTime or a string accepted by {@link http://php.net/manual/function.strtotime.php strtotime}.
+     * @param  string|\DateTimeZone             $toTimezone=''   The timezone to set; leave empty to use the value of $fromTimezone (if it's empty we'll use the default timezone or the timezone associated to $value if it's already a `\DateTime`).
+     * @param  string|\DateTimeZone             $fromTimezone='' The original timezone of $value; leave empty to use the default timezone (or the timezone associated to $value if it's already a `\DateTime`).
+     * @return \DateTime|null                   Returns null if $value is empty, a `\DateTime` instance otherwise.
      * @throws \Punic\Exception\BadArgumentType Throws an exception if $value is not empty and can't be converted to a `\DateTime` instance or if $toTimezone is not empty and is not valid.
      * @example Convert a Unix timestamp to a \DateTime instance with the current time zone:
-     * ```php
-     * \Punic\Calendar::toDateTime(1409648286);
-     * ```
+     *                                                          ```php
+     *                                                          \Punic\Calendar::toDateTime(1409648286);
+     *                                                          ```
      * @example Convert a Unix timestamp to a \DateTime instance with a specific time zone:
-     * ```php
-     * \Punic\Calendar::toDateTime(1409648286, 'Europe/Rome');
-     * \Punic\Calendar::toDateTime(1409648286, new \DateTimeZone('Europe/Rome'));
-     * ```
+     *                                                          ```php
+     *                                                          \Punic\Calendar::toDateTime(1409648286, 'Europe/Rome');
+     *                                                          \Punic\Calendar::toDateTime(1409648286, new \DateTimeZone('Europe/Rome'));
+     *                                                          ```
      * @example Convert a string to a \DateTime instance with the current time zone:
-     * ```php
-     * \Punic\Calendar::toDateTime('2014-03-07 13:30');
-     * ```
+     *                                                          ```php
+     *                                                          \Punic\Calendar::toDateTime('2014-03-07 13:30');
+     *                                                          ```
      * @example Convert a string to a \DateTime instance with a specific time zone:
-     * ```php
-     * \Punic\Calendar::toDateTime('2014-03-07 13:30', 'Europe/Rome');
-     * ```
-     * Please remark that in this case '2014-03-07 13:30' is converted to a \DateTime instance with the current timezone, and <u>after</u> we change the timezone.
-     * So, if your system default timezone is 'America/Los_Angeles' (GMT -8), the resulting date/time will be '2014-03-07 22:30 GMT+1' since it'll be converted to 'Europe/Rome' (GMT +1)
+     *                                                          ```php
+     *                                                          \Punic\Calendar::toDateTime('2014-03-07 13:30', 'Europe/Rome');
+     *                                                          ```
+     *                                                          Please remark that in this case '2014-03-07 13:30' is converted to a \DateTime instance with the current timezone, and <u>after</u> we change the timezone.
+     *                                                          So, if your system default timezone is 'America/Los_Angeles' (GMT -8), the resulting date/time will be '2014-03-07 22:30 GMT+1' since it'll be converted to 'Europe/Rome' (GMT +1)
      */
     public static function toDateTime($value, $toTimezone = '', $fromTimezone = '')
     {
@@ -116,7 +116,7 @@ class Calendar
 
     /**
      * Converts a format string from {@link http://php.net/manual/en/function.date.php#refsect1-function.date-parameters PHP's date format} to {@link http://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table ISO format}.
-     * @param string $format The PHP date/time format string to convert.
+     * @param  string $format The PHP date/time format string to convert.
      * @return string Returns the ISO date/time format corresponding to the specified PHP date/time format.
      */
     public static function convertPhpToIsoFormat($format)
@@ -180,13 +180,13 @@ class Calendar
 
     /**
      * Get the name of an era.
-     * @param number|\DateTime $value The year number or the \DateTime instance for which you want the name of the era.
-     * @param string $width='abbreviated' The format name; it can be 'wide' (eg 'Before Christ'), 'abbreviated' (eg 'BC') or 'narrow' (eg 'B').
-     * @param string $locale='' The locale to use. If empty we'll use the default locale set with {@link \Punic\Data::setDefaultLocale()}.
-     * @return string Returns an empty string if $value is empty, the name of the era otherwise.
+     * @param  number|\DateTime                 $value               The year number or the \DateTime instance for which you want the name of the era.
+     * @param  string                           $width='abbreviated' The format name; it can be 'wide' (eg 'Before Christ'), 'abbreviated' (eg 'BC') or 'narrow' (eg 'B').
+     * @param  string                           $locale=''           The locale to use. If empty we'll use the default locale set with {@link \Punic\Data::setDefaultLocale()}.
+     * @return string                           Returns an empty string if $value is empty, the name of the era otherwise.
      * @throws \Punic\Exception\BadArgumentType Throws a BadArgumentType exception if $value is not valid.
-     * @throws \Punic\Exception\ValueNotInList Throws a ValueNotInList exception if $width is not valid.
-     * @throws \Punic\Exception Throws a generic exception in case of other problems (for instance if you specify an invalid locale).
+     * @throws \Punic\Exception\ValueNotInList  Throws a ValueNotInList exception if $width is not valid.
+     * @throws \Punic\Exception                 Throws a generic exception in case of other problems (for instance if you specify an invalid locale).
      */
     public static function getEraName($value, $width = 'abbreviated', $locale = '')
     {
@@ -220,14 +220,14 @@ class Calendar
 
     /**
      * Get the name of a month.
-     * @param number|\DateTime $value The month number (1-12) or a \DateTime instance for which you want the name of the month.
-     * @param string $width='wide' The format name; it can be 'wide' (eg 'January'), 'abbreviated' (eg 'Jan') or 'narrow' (eg 'J').
-     * @param string $locale='' The locale to use. If empty we'll use the default locale set with {@link \Punic\Data::setDefaultLocale()}.
-     * @param bool $standAlone=false Set to true to return the form used independently (such as in calendar header), set to false if the month name will be part of a date.
-     * @return string Returns an empty string if $value is empty, the name of the month otherwise.
+     * @param  number|\DateTime                 $value            The month number (1-12) or a \DateTime instance for which you want the name of the month.
+     * @param  string                           $width='wide'     The format name; it can be 'wide' (eg 'January'), 'abbreviated' (eg 'Jan') or 'narrow' (eg 'J').
+     * @param  string                           $locale=''        The locale to use. If empty we'll use the default locale set with {@link \Punic\Data::setDefaultLocale()}.
+     * @param  bool                             $standAlone=false Set to true to return the form used independently (such as in calendar header), set to false if the month name will be part of a date.
+     * @return string                           Returns an empty string if $value is empty, the name of the month otherwise.
      * @throws \Punic\Exception\BadArgumentType Throws a BadArgumentType exception if $value is not valid.
-     * @throws \Punic\Exception\ValueNotInList Throws a ValueNotInList exception if $width is not valid.
-     * @throws \Punic\Exception Throws a generic exception in case of other problems (for instance if you specify an invalid locale).
+     * @throws \Punic\Exception\ValueNotInList  Throws a ValueNotInList exception if $width is not valid.
+     * @throws \Punic\Exception                 Throws a generic exception in case of other problems (for instance if you specify an invalid locale).
      */
     public static function getMonthName($value, $width = 'wide', $locale = '', $standAlone = false)
     {
@@ -261,14 +261,14 @@ class Calendar
 
     /**
      * Get the name of a week day.
-     * @param number|\DateTime $value A week day number (from 0-Sunday to 6-Saturnday) or a \DateTime instance for which you want the name of the day of the week.
-     * @param string $width='wide' The format name; it can be 'wide' (eg 'Sunday'), 'abbreviated' (eg 'Sun'), 'short' (eg 'Su') or 'narrow' (eg 'S').
-     * @param string $locale='' The locale to use. If empty we'll use the default locale set with {@link \Punic\Data::setDefaultLocale()}.
-     * @param bool $standAlone=false Set to true to return the form used independently (such as in calendar header), set to false if the week day name will be part of a date.
-     * @return string Returns an empty string if $value is empty, the name of the week day name otherwise.
+     * @param  number|\DateTime                 $value            A week day number (from 0-Sunday to 6-Saturnday) or a \DateTime instance for which you want the name of the day of the week.
+     * @param  string                           $width='wide'     The format name; it can be 'wide' (eg 'Sunday'), 'abbreviated' (eg 'Sun'), 'short' (eg 'Su') or 'narrow' (eg 'S').
+     * @param  string                           $locale=''        The locale to use. If empty we'll use the default locale set with {@link \Punic\Data::setDefaultLocale()}.
+     * @param  bool                             $standAlone=false Set to true to return the form used independently (such as in calendar header), set to false if the week day name will be part of a date.
+     * @return string                           Returns an empty string if $value is empty, the name of the week day name otherwise.
      * @throws \Punic\Exception\BadArgumentType Throws a BadArgumentType exception if $value is not valid.
-     * @throws \Punic\Exception\ValueNotInList Throws a ValueNotInList exception if $width is not valid.
-     * @throws \Punic\Exception Throws a generic exception in case of other problems (for instance if you specify an invalid locale).
+     * @throws \Punic\Exception\ValueNotInList  Throws a ValueNotInList exception if $width is not valid.
+     * @throws \Punic\Exception                 Throws a generic exception in case of other problems (for instance if you specify an invalid locale).
      */
     public static function getWeekdayName($value, $width = 'wide', $locale = '', $standAlone = false)
     {
@@ -304,14 +304,14 @@ class Calendar
 
     /**
      * Get the name of a quarter.
-     * @param number|\DateTime $value A quarter number (from 1 to 4) or a \DateTime instance for which you want the name of the day of the quarter.
-     * @param string $width='wide' The format name; it can be 'wide' (eg '1st quarter'), 'abbreviated' (eg 'Q1') or 'narrow' (eg '1').
-     * @param string $locale='' The locale to use. If empty we'll use the default locale set with {@link \Punic\Data::setDefaultLocale()}.
-     * @param bool $standAlone=false Set to true to return the form used independently (such as in calendar header), set to false if the quarter name will be part of a date.
-     * @return string Returns an empty string if $value is empty, the name of the quarter name otherwise.
+     * @param  number|\DateTime                 $value            A quarter number (from 1 to 4) or a \DateTime instance for which you want the name of the day of the quarter.
+     * @param  string                           $width='wide'     The format name; it can be 'wide' (eg '1st quarter'), 'abbreviated' (eg 'Q1') or 'narrow' (eg '1').
+     * @param  string                           $locale=''        The locale to use. If empty we'll use the default locale set with {@link \Punic\Data::setDefaultLocale()}.
+     * @param  bool                             $standAlone=false Set to true to return the form used independently (such as in calendar header), set to false if the quarter name will be part of a date.
+     * @return string                           Returns an empty string if $value is empty, the name of the quarter name otherwise.
      * @throws \Punic\Exception\BadArgumentType Throws a BadArgumentType exception if $value is not valid.
-     * @throws \Punic\Exception\ValueNotInList Throws a ValueNotInList exception if $width is not valid.
-     * @throws \Punic\Exception Throws a generic exception in case of other problems (for instance if you specify an invalid locale).
+     * @throws \Punic\Exception\ValueNotInList  Throws a ValueNotInList exception if $width is not valid.
+     * @throws \Punic\Exception                 Throws a generic exception in case of other problems (for instance if you specify an invalid locale).
      */
     public static function getQuarterName($value, $width = 'wide', $locale = '', $standAlone = false)
     {
@@ -345,14 +345,14 @@ class Calendar
 
     /**
      * Get the name of a day period (AM/PM).
-     * @param number|string|\DateTime $value An hour (from 0 to 23), a standard period name ('am' or 'pm', lower or upper case) a \DateTime instance for which you want the name of the day period.
-     * @param string $width='wide' The format name; it can be 'wide' (eg 'AM'), 'abbreviated' (eg 'AM') or 'narrow' (eg 'a').
-     * @param string $locale='' The locale to use. If empty we'll use the default locale set with {@link \Punic\Data::setDefaultLocale()}.
-     * @param bool $standAlone=false Set to true to return the form used independently (such as in calendar header), set to false if the day period name will be part of a date.
-     * @return string Returns an empty string if $value is empty, the name of the day period name otherwise.
+     * @param  number|string|\DateTime          $value            An hour (from 0 to 23), a standard period name ('am' or 'pm', lower or upper case) a \DateTime instance for which you want the name of the day period.
+     * @param  string                           $width='wide'     The format name; it can be 'wide' (eg 'AM'), 'abbreviated' (eg 'AM') or 'narrow' (eg 'a').
+     * @param  string                           $locale=''        The locale to use. If empty we'll use the default locale set with {@link \Punic\Data::setDefaultLocale()}.
+     * @param  bool                             $standAlone=false Set to true to return the form used independently (such as in calendar header), set to false if the day period name will be part of a date.
+     * @return string                           Returns an empty string if $value is empty, the name of the day period name otherwise.
      * @throws \Punic\Exception\BadArgumentType Throws a BadArgumentType exception if $value is not valid.
-     * @throws \Punic\Exception\ValueNotInList Throws a ValueNotInList exception if $width is not valid.
-     * @throws \Punic\Exception Throws a generic exception in case of other problems (for instance if you specify an invalid locale).
+     * @throws \Punic\Exception\ValueNotInList  Throws a ValueNotInList exception if $width is not valid.
+     * @throws \Punic\Exception                 Throws a generic exception in case of other problems (for instance if you specify an invalid locale).
      */
     public static function getDayperiodName($value, $width = 'wide', $locale = '', $standAlone = false)
     {
@@ -396,17 +396,17 @@ class Calendar
 
     /**
      * Returns the localized name of a timezone, no location-specific.
-     * @param string|\DateTime|\DateTimeZone $value The php name of a timezone, or a \DateTime instance or a \DateTimeZone instance for which you want the localized timezone name.
-     * @param string $width='long' The format name; it can be 'long' (eg 'Greenwich Mean Time') or 'short' (eg 'GMT').
-     * @param string $kind='' Set to 'daylight' to retrieve the daylight saving time name, set to 'standard' to retrieve the standard time, set to 'generic' to retrieve the generic name, set to '' to determine automatically the dst (if $value is \DateTime) or the generic (otherwise).
-     * @param string $locale='' The locale to use. If empty we'll use the default locale set with {@link \Punic\Data::setDefaultLocale()}.
-     * @return string Returns an empty string if the timezone has not been found (maybe we don't have the data in the specified $width), the timezone name otherwise.
-     * @throws \Punic\Exception Throws a generic exception in case of problems (for instance if you specify an invalid locale).
+     * @param  string|\DateTime|\DateTimeZone $value        The php name of a timezone, or a \DateTime instance or a \DateTimeZone instance for which you want the localized timezone name.
+     * @param  string                         $width='long' The format name; it can be 'long' (eg 'Greenwich Mean Time') or 'short' (eg 'GMT').
+     * @param  string                         $kind=''      Set to 'daylight' to retrieve the daylight saving time name, set to 'standard' to retrieve the standard time, set to 'generic' to retrieve the generic name, set to '' to determine automatically the dst (if $value is \DateTime) or the generic (otherwise).
+     * @param  string                         $locale=''    The locale to use. If empty we'll use the default locale set with {@link \Punic\Data::setDefaultLocale()}.
+     * @return string                         Returns an empty string if the timezone has not been found (maybe we don't have the data in the specified $width), the timezone name otherwise.
+     * @throws \Punic\Exception               Throws a generic exception in case of problems (for instance if you specify an invalid locale).
      */
     public static function getTimezoneNameNoLocationSpecific($value, $width = 'long', $kind = '', $locale = '')
     {
         $cacheKey = json_encode(array($value, $width, $kind, $locale));
-        if(isset(self::$timezoneCache[$cacheKey])) {
+        if (isset(self::$timezoneCache[$cacheKey])) {
             return self::$timezoneCache[$cacheKey];
         }
 
@@ -523,10 +523,10 @@ class Calendar
 
     /**
      * Returns the localized name of an exemplar city for a specific timezone
-     * @param string|\DateTime|\DateTimeZone $value The php name of a timezone, or a \DateTime instance or a \DateTimeZone instance
-     * @param bool $returnUnknownIfNotFound=true true If the exemplar city is not found, shall we return the translation of 'Unknown City'?
-     * @param string $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
-     * @return string Returns an empty string if the exemplar city hasn't been found and $returnUnknownIfNotFound is false
+     * @param  string|\DateTime|\DateTimeZone $value                        The php name of a timezone, or a \DateTime instance or a \DateTimeZone instance
+     * @param  bool                           $returnUnknownIfNotFound=true true If the exemplar city is not found, shall we return the translation of 'Unknown City'?
+     * @param  string                         $locale=''                    The locale to use. If empty we'll use the default locale set in \Punic\Data
+     * @return string                         Returns an empty string if the exemplar city hasn't been found and $returnUnknownIfNotFound is false
      */
     public static function getTimezoneExemplarCity($value, $returnUnknownIfNotFound = true, $locale = '')
     {
@@ -577,7 +577,7 @@ class Calendar
 
     /**
      * Returns true if a locale has a 12-hour clock, false if 24-hour clock
-     * @param string $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
+     * @param  string           $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
      * @return bool
      * @throws \Punic\Exception Throws an exception in case of problems
      */
@@ -596,8 +596,8 @@ class Calendar
 
     /**
      * Retrieve the first weekday for a specific locale (from 0-Sunday to 6-Saturnday)
-     * @param string $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
-     * @return int Returns a number from 0 (Sunday) to 7 (Saturnday)
+     * @param  string $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
+     * @return int    Returns a number from 0 (Sunday) to 7 (Saturnday)
      */
     public static function getFirstWeekday($locale = '')
     {
@@ -618,9 +618,9 @@ class Calendar
 
     /**
      * Returns the sorted list of weekdays, starting from {@link getFirstWeekday}
-     * @param string|false $namesWidth=false If false you'll get only the list of weekday identifiers (for instance: [0, 1, 2, 3, 4, 5, 6]),
-     * If it's a string it must be one accepted by {@link getWeekdayName}, and you'll get an array like this: [{id: 0, name: 'Monday', ..., {id: 6, name: 'Sunday'}]
-     * @param string $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
+     * @param  string|false $namesWidth=false If false you'll get only the list of weekday identifiers (for instance: [0, 1, 2, 3, 4, 5, 6]),
+     *                                        If it's a string it must be one accepted by {@link getWeekdayName}, and you'll get an array like this: [{id: 0, name: 'Monday', ..., {id: 6, name: 'Sunday'}]
+     * @param  string       $locale=''        The locale to use. If empty we'll use the default locale set in \Punic\Data
      * @return array
      */
     public static function getSortedWeekdays($namesWidth = false, $locale = '')
@@ -648,9 +648,9 @@ class Calendar
 
     /**
      * Get the ISO format for a date
-     * @param string $width The format name; it can be 'full' (eg 'EEEE, MMMM d, y' - 'Wednesday, August 20, 2014'), 'long' (eg 'MMMM d, y' - 'August 20, 2014'), 'medium' (eg 'MMM d, y' - 'August 20, 2014') or 'short' (eg 'M/d/yy' - '8/20/14')
-     * @param string $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
-     * @return string Returns the requested ISO format
+     * @param  string    $width     The format name; it can be 'full' (eg 'EEEE, MMMM d, y' - 'Wednesday, August 20, 2014'), 'long' (eg 'MMMM d, y' - 'August 20, 2014'), 'medium' (eg 'MMM d, y' - 'August 20, 2014') or 'short' (eg 'M/d/yy' - '8/20/14')
+     * @param  string    $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
+     * @return string    Returns the requested ISO format
      * @throws Exception Throws an exception in case of problems
      * @link http://cldr.unicode.org/translation/date-time-patterns
      * @link http://cldr.unicode.org/translation/date-time
@@ -669,9 +669,9 @@ class Calendar
 
     /**
      * Get the ISO format for a time
-     * @param string $width The format name; it can be 'full' (eg 'h:mm:ss a zzzz' - '11:42:13 AM GMT+2:00'), 'long' (eg 'h:mm:ss a z' - '11:42:13 AM GMT+2:00'), 'medium' (eg 'h:mm:ss a' - '11:42:13 AM') or 'short' (eg 'h:mm a' - '11:42 AM')
-     * @param string $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
-     * @return string Returns the requested ISO format
+     * @param  string           $width     The format name; it can be 'full' (eg 'h:mm:ss a zzzz' - '11:42:13 AM GMT+2:00'), 'long' (eg 'h:mm:ss a z' - '11:42:13 AM GMT+2:00'), 'medium' (eg 'h:mm:ss a' - '11:42:13 AM') or 'short' (eg 'h:mm a' - '11:42 AM')
+     * @param  string           $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
+     * @return string           Returns the requested ISO format
      * @throws \Punic\Exception Throws an exception in case of problems
      * @link http://cldr.unicode.org/translation/date-time-patterns
      * @link http://cldr.unicode.org/translation/date-time
@@ -690,9 +690,9 @@ class Calendar
 
     /**
      * Get the ISO format for a date/time
-     * @param string $width The format name; it can be 'full', 'long', 'medium', 'short' or a combination for date+time like 'full|short' or a combination for format+date+time like 'full|full|short'
-     * @param string $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
-     * @return string Returns the requested ISO format
+     * @param  string           $width     The format name; it can be 'full', 'long', 'medium', 'short' or a combination for date+time like 'full|short' or a combination for format+date+time like 'full|full|short'
+     * @param  string           $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
+     * @return string           Returns the requested ISO format
      * @throws \Punic\Exception Throws an exception in case of problems
      * @link http://cldr.unicode.org/translation/date-time-patterns
      * @link http://cldr.unicode.org/translation/date-time
@@ -756,9 +756,9 @@ class Calendar
 
     /**
      * Returns the difference in days between two dates (or between a date and today)
-     * @param \DateTime $dateEnd The first date
-     * @param \DateTime|null $dateStart=null The final date (if it has a timezone different than $dateEnd, we'll use the one of $dateEnd)
-     * @return int Returns the diffence $dateEnd - $dateStart in days
+     * @param  \DateTime                 $dateEnd        The first date
+     * @param  \DateTime|null            $dateStart=null The final date (if it has a timezone different than $dateEnd, we'll use the one of $dateEnd)
+     * @return int                       Returns the diffence $dateEnd - $dateStart in days
      * @throws Exception\BadArgumentType
      */
     public static function getDeltaDays($dateEnd, $dateStart = null)
@@ -785,17 +785,16 @@ class Calendar
 
     /**
      * Describe an interval between two dates (eg '2 days and 4 hours').
-     * @param \DateTime $dateEnd The first date
-     * @param \DateTime|null $dateStart=null The final date (if it has a timezone different than $dateEnd, we'll use the one of $dateEnd)
-     * @param int $maxParts=2 The maximim parts (eg with 2 you may have '2 days and 4 hours', with 3 '2 days, 4 hours and 24 minutes')
-     * @param string $width='short' The format name; it can be 'long' (eg '3 seconds'), 'short' (eg '3 s') or 'narrow' (eg '3s')
-     * @param string $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
+     * @param  \DateTime                 $dateEnd        The first date
+     * @param  \DateTime|null            $dateStart=null The final date (if it has a timezone different than $dateEnd, we'll use the one of $dateEnd)
+     * @param  int                       $maxParts=2     The maximim parts (eg with 2 you may have '2 days and 4 hours', with 3 '2 days, 4 hours and 24 minutes')
+     * @param  string                    $width='short'  The format name; it can be 'long' (eg '3 seconds'), 'short' (eg '3 s') or 'narrow' (eg '3s')
+     * @param  string                    $locale=''      The locale to use. If empty we'll use the default locale set in \Punic\Data
      * @return string
      * @throws Exception\BadArgumentType
      */
     public static function describeInterval($dateEnd, $dateStart = null, $maxParts = 2, $width = 'short', $locale = '')
     {
-
         if (!is_a($dateEnd, '\\DateTime')) {
             throw new Exception\BadArgumentType($dateEnd, '\\DateTime');
         }
@@ -872,11 +871,11 @@ class Calendar
 
     /**
      * Format a date
-     * @param \DateTime $value The \DateTime instance for which you want the localized textual representation
-     * @param string $width The format name; it can be 'full' (eg 'EEEE, MMMM d, y' - 'Wednesday, August 20, 2014'), 'long' (eg 'MMMM d, y' - 'August 20, 2014'), 'medium' (eg 'MMM d, y' - 'August 20, 2014') or 'short' (eg 'M/d/yy' - '8/20/14').
-     *                      You can also append a caret ('^') or an asterisk ('*') to $width. If so, special day names may be used (like 'Today', 'Yesterday', 'Tomorrow' with '^' and 'today', 'yesterday', 'tomorrow' width '*') instead of the date.
-     * @param string $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
-     * @return string Returns an empty string if $value is empty, the localized textual representation otherwise
+     * @param  \DateTime        $value     The \DateTime instance for which you want the localized textual representation
+     * @param  string           $width     The format name; it can be 'full' (eg 'EEEE, MMMM d, y' - 'Wednesday, August 20, 2014'), 'long' (eg 'MMMM d, y' - 'August 20, 2014'), 'medium' (eg 'MMM d, y' - 'August 20, 2014') or 'short' (eg 'M/d/yy' - '8/20/14').
+     *                                     You can also append a caret ('^') or an asterisk ('*') to $width. If so, special day names may be used (like 'Today', 'Yesterday', 'Tomorrow' with '^' and 'today', 'yesterday', 'tomorrow' width '*') instead of the date.
+     * @param  string           $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
+     * @return string           Returns an empty string if $value is empty, the localized textual representation otherwise
      * @throws \Punic\Exception Throws an exception in case of problems
      * @link http://cldr.unicode.org/translation/date-time-patterns
      * @link http://cldr.unicode.org/translation/date-time
@@ -902,13 +901,13 @@ class Calendar
 
     /**
      * Format a date (extended version: various date/time representations - see toDateTime())
-     * @param number|\DateTime|string $value An Unix timestamp, a `\DateTime` instance or a string accepted by {@link http://php.net/manual/function.strtotime.php strtotime}.
-     * @param string $width The format name; it can be 'full' (eg 'EEEE, MMMM d, y' - 'Wednesday, August 20, 2014'), 'long' (eg 'MMMM d, y' - 'August 20, 2014'), 'medium' (eg 'MMM d, y' - 'August 20, 2014') or 'short' (eg 'M/d/yy' - '8/20/14')
-     *                      You can also append a caret ('^') or an asterisk ('*') to $width. If so, special day names may be used (like 'Today', 'Yesterday', 'Tomorrow' with '^' and 'today', 'yesterday', 'tomorrow' width '*') instead of the date.
-     * @param string|\DateTimeZone $toTimezone='' The timezone to set; leave empty to use the default timezone (or the timezone associated to $value if it's already a \DateTime)
-     * @param string $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
-     * @return string Returns an empty string if $value is empty, the localized textual representation otherwise
-     * @throws \Punic\Exception Throws an exception in case of problems
+     * @param  number|\DateTime|string $value         An Unix timestamp, a `\DateTime` instance or a string accepted by {@link http://php.net/manual/function.strtotime.php strtotime}.
+     * @param  string                  $width         The format name; it can be 'full' (eg 'EEEE, MMMM d, y' - 'Wednesday, August 20, 2014'), 'long' (eg 'MMMM d, y' - 'August 20, 2014'), 'medium' (eg 'MMM d, y' - 'August 20, 2014') or 'short' (eg 'M/d/yy' - '8/20/14')
+     *                                                You can also append a caret ('^') or an asterisk ('*') to $width. If so, special day names may be used (like 'Today', 'Yesterday', 'Tomorrow' with '^' and 'today', 'yesterday', 'tomorrow' width '*') instead of the date.
+     * @param  string|\DateTimeZone    $toTimezone='' The timezone to set; leave empty to use the default timezone (or the timezone associated to $value if it's already a \DateTime)
+     * @param  string                  $locale=''     The locale to use. If empty we'll use the default locale set in \Punic\Data
+     * @return string                  Returns an empty string if $value is empty, the localized textual representation otherwise
+     * @throws \Punic\Exception        Throws an exception in case of problems
      * @see toDateTime()
      * @link http://cldr.unicode.org/translation/date-time-patterns
      * @link http://cldr.unicode.org/translation/date-time
@@ -925,10 +924,10 @@ class Calendar
 
     /**
      * Format a time
-     * @param \DateTime $value The \DateTime instance for which you want the localized textual representation
-     * @param string $width The format name; it can be 'full' (eg 'h:mm:ss a zzzz' - '11:42:13 AM GMT+2:00'), 'long' (eg 'h:mm:ss a z' - '11:42:13 AM GMT+2:00'), 'medium' (eg 'h:mm:ss a' - '11:42:13 AM') or 'short' (eg 'h:mm a' - '11:42 AM')
-     * @param string $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
-     * @return string Returns an empty string if $value is empty, the localized textual representation otherwise
+     * @param  \DateTime        $value     The \DateTime instance for which you want the localized textual representation
+     * @param  string           $width     The format name; it can be 'full' (eg 'h:mm:ss a zzzz' - '11:42:13 AM GMT+2:00'), 'long' (eg 'h:mm:ss a z' - '11:42:13 AM GMT+2:00'), 'medium' (eg 'h:mm:ss a' - '11:42:13 AM') or 'short' (eg 'h:mm a' - '11:42 AM')
+     * @param  string           $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
+     * @return string           Returns an empty string if $value is empty, the localized textual representation otherwise
      * @throws \Punic\Exception Throws an exception in case of problems
      * @link http://cldr.unicode.org/translation/date-time-patterns
      * @link http://cldr.unicode.org/translation/date-time
@@ -945,12 +944,12 @@ class Calendar
 
     /**
      * Format a time (extended version: various date/time representations - see toDateTime())
-     * @param number|\DateTime|string $value An Unix timestamp, a `\DateTime` instance or a string accepted by {@link http://php.net/manual/function.strtotime.php strtotime}.
-     * @param string $width The format name; it can be 'full' (eg 'h:mm:ss a zzzz' - '11:42:13 AM GMT+2:00'), 'long' (eg 'h:mm:ss a z' - '11:42:13 AM GMT+2:00'), 'medium' (eg 'h:mm:ss a' - '11:42:13 AM') or 'short' (eg 'h:mm a' - '11:42 AM')
-     * @param string|\DateTimeZone $toTimezone='' The timezone to set; leave empty to use the default timezone (or the timezone associated to $value if it's already a \DateTime)
-     * @param string $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
-     * @return string Returns an empty string if $value is empty, the localized textual representation otherwise
-     * @throws \Punic\Exception Throws an exception in case of problems
+     * @param  number|\DateTime|string $value         An Unix timestamp, a `\DateTime` instance or a string accepted by {@link http://php.net/manual/function.strtotime.php strtotime}.
+     * @param  string                  $width         The format name; it can be 'full' (eg 'h:mm:ss a zzzz' - '11:42:13 AM GMT+2:00'), 'long' (eg 'h:mm:ss a z' - '11:42:13 AM GMT+2:00'), 'medium' (eg 'h:mm:ss a' - '11:42:13 AM') or 'short' (eg 'h:mm a' - '11:42 AM')
+     * @param  string|\DateTimeZone    $toTimezone='' The timezone to set; leave empty to use the default timezone (or the timezone associated to $value if it's already a \DateTime)
+     * @param  string                  $locale=''     The locale to use. If empty we'll use the default locale set in \Punic\Data
+     * @return string                  Returns an empty string if $value is empty, the localized textual representation otherwise
+     * @throws \Punic\Exception        Throws an exception in case of problems
      * @see toDateTime()
      * @link http://cldr.unicode.org/translation/date-time-patterns
      * @link http://cldr.unicode.org/translation/date-time
@@ -967,11 +966,11 @@ class Calendar
 
     /**
      * Format a date/time
-     * @param \DateTime $value The \DateTime instance for which you want the localized textual representation
-     * @param string $width The format name; it can be 'full', 'long', 'medium', 'short' or a combination for date+time like 'full|short' or a combination for format+date+time like 'full|full|short'
-     *                      You can also append an asterisk ('*') to the date parh of $width. If so, special day names may be used (like 'Today', 'Yesterday', 'Tomorrow') instead of the date part.
-     * @param string $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
-     * @return string Returns an empty string if $value is empty, the localized textual representation otherwise
+     * @param  \DateTime        $value     The \DateTime instance for which you want the localized textual representation
+     * @param  string           $width     The format name; it can be 'full', 'long', 'medium', 'short' or a combination for date+time like 'full|short' or a combination for format+date+time like 'full|full|short'
+     *                                     You can also append an asterisk ('*') to the date parh of $width. If so, special day names may be used (like 'Today', 'Yesterday', 'Tomorrow') instead of the date part.
+     * @param  string           $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
+     * @return string           Returns an empty string if $value is empty, the localized textual representation otherwise
      * @throws \Punic\Exception Throws an exception in case of problems
      * @link http://cldr.unicode.org/translation/date-time-patterns
      * @link http://cldr.unicode.org/translation/date-time
@@ -998,7 +997,6 @@ class Calendar
                 if (strlen($dayName)) {
                     $overrideDateFormat = "'$dayName'";
                 }
-
             }
         }
 
@@ -1011,13 +1009,13 @@ class Calendar
 
     /**
      * Format a date/time (extended version: various date/time representations - see toDateTime())
-     * @param number|\DateTime|string $value An Unix timestamp, a `\DateTime` instance or a string accepted by {@link http://php.net/manual/function.strtotime.php strtotime}.
-     * @param string $width The format name; it can be 'full', 'long', 'medium', 'short' or a combination for date+time like 'full|short' or a combination for format+date+time like 'full|full|short'
-     *                      You can also append an asterisk ('*') to the date parh of $width. If so, special day names may be used (like 'Today', 'Yesterday', 'Tomorrow') instead of the date part.
-     * @param string|\DateTimeZone $toTimezone='' The timezone to set; leave empty to use the default timezone (or the timezone associated to $value if it's already a \DateTime)
-     * @param string $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
-     * @return string Returns an empty string if $value is empty, the localized textual representation otherwise
-     * @throws \Punic\Exception Throws an exception in case of problems
+     * @param  number|\DateTime|string $value         An Unix timestamp, a `\DateTime` instance or a string accepted by {@link http://php.net/manual/function.strtotime.php strtotime}.
+     * @param  string                  $width         The format name; it can be 'full', 'long', 'medium', 'short' or a combination for date+time like 'full|short' or a combination for format+date+time like 'full|full|short'
+     *                                                You can also append an asterisk ('*') to the date parh of $width. If so, special day names may be used (like 'Today', 'Yesterday', 'Tomorrow') instead of the date part.
+     * @param  string|\DateTimeZone    $toTimezone='' The timezone to set; leave empty to use the default timezone (or the timezone associated to $value if it's already a \DateTime)
+     * @param  string                  $locale=''     The locale to use. If empty we'll use the default locale set in \Punic\Data
+     * @return string                  Returns an empty string if $value is empty, the localized textual representation otherwise
+     * @throws \Punic\Exception        Throws an exception in case of problems
      * @see toDateTime()
      * @link http://cldr.unicode.org/translation/date-time-patterns
      * @link http://cldr.unicode.org/translation/date-time
@@ -1034,10 +1032,10 @@ class Calendar
 
     /**
      * Format a date and/or time
-     * @param \DateTime $value The \DateTime instance for which you want the localized textual representation
-     * @param string $format The ISO format that specify how to render the date/time
-     * @param string $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
-     * @return string Returns an empty string if $value is empty, the localized textual representation otherwise
+     * @param  \DateTime        $value     The \DateTime instance for which you want the localized textual representation
+     * @param  string           $format    The ISO format that specify how to render the date/time
+     * @param  string           $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
+     * @return string           Returns an empty string if $value is empty, the localized textual representation otherwise
      * @throws \Punic\Exception Throws an exception in case of problems
      * @link http://cldr.unicode.org/translation/date-time-patterns
      * @link http://cldr.unicode.org/translation/date-time
@@ -1145,12 +1143,12 @@ class Calendar
     }
     /**
      * Format a date and/or time (extended version: various date/time representations - see toDateTime())
-     * @param number|\DateTime|string $value An Unix timestamp, a `\DateTime` instance or a string accepted by {@link http://php.net/manual/function.strtotime.php strtotime}.
-     * @param string $format The ISO format that specify how to render the date/time
-     * @param string|\DateTimeZone $toTimezone='' The timezone to set; leave empty to use the default timezone (or the timezone associated to $value if it's already a \DateTime)
-     * @param string $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
-     * @return string Returns an empty string if $value is empty, the localized textual representation otherwise
-     * @throws \Punic\Exception Throws an exception in case of problems
+     * @param  number|\DateTime|string $value         An Unix timestamp, a `\DateTime` instance or a string accepted by {@link http://php.net/manual/function.strtotime.php strtotime}.
+     * @param  string                  $format        The ISO format that specify how to render the date/time
+     * @param  string|\DateTimeZone    $toTimezone='' The timezone to set; leave empty to use the default timezone (or the timezone associated to $value if it's already a \DateTime)
+     * @param  string                  $locale=''     The locale to use. If empty we'll use the default locale set in \Punic\Data
+     * @return string                  Returns an empty string if $value is empty, the localized textual representation otherwise
+     * @throws \Punic\Exception        Throws an exception in case of problems
      * @link http://cldr.unicode.org/translation/date-time-patterns
      * @link http://cldr.unicode.org/translation/date-time
      * @link http://www.unicode.org/reports/tr35/tr35-dates.html#Date_Format_Patterns
@@ -1166,10 +1164,10 @@ class Calendar
 
     /**
      * Retrieve the relative day name (eg 'yesterday', 'tomorrow'), if available
-     * @param \DateTime $datetime The date for which you want the relative day name
-     * @param bool $ucFirst=false Force first letter to be upper case?
-     * @param string $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
-     * @return string Returns the relative name if available, otherwise returns an empty string
+     * @param  \DateTime $datetime      The date for which you want the relative day name
+     * @param  bool      $ucFirst=false Force first letter to be upper case?
+     * @param  string    $locale=''     The locale to use. If empty we'll use the default locale set in \Punic\Data
+     * @return string    Returns the relative name if available, otherwise returns an empty string
      */
     public static function getDateRelativeName($datetime, $ucFirst = false, $locale = '')
     {
@@ -1396,9 +1394,9 @@ class Calendar
         $format = isset($data['gmtFormat']) ? $data['gmtFormat'] : 'GMT%1$s';
         switch ($count) {
             case 1:
-                return sprintf($format, $sign . $hours . (($minutes === 0) ? '' : (':' . substr('0' . $minutes, -2))));
+                return sprintf($format, $sign.$hours.(($minutes === 0) ? '' : (':'.substr('0'.$minutes, -2))));
             case 4:
-                return sprintf($format, $sign . $hours . ':' . substr('0' . $minutes, -2));
+                return sprintf($format, $sign.$hours.':'.substr('0'.$minutes, -2));
             default:
                 throw new Exception\ValueNotInList($count, array(1, 4));
         }
@@ -1424,7 +1422,7 @@ class Calendar
     {
         $y = $value->format('o');
         if ($count === 2) {
-            $y = substr('0' . $y, -2);
+            $y = substr('0'.$y, -2);
         } else {
             if ($count > strlen($y)) {
                 $y = str_pad($y, $count, '0', STR_PAD_LEFT);
@@ -1457,7 +1455,7 @@ class Calendar
             case 1:
                 return strval($quarter);
             case 2:
-                return '0' . strval($quarter);
+                return '0'.strval($quarter);
             case 3:
                 return static::getQuarterName($quarter, 'abbreviated', $locale, $standAlone);
             case 4:
@@ -1546,8 +1544,8 @@ class Calendar
         $minutes = intval(floor($seconds / 60));
         $seconds -= $minutes * 60;
         $partsWithoutSeconds = array();
-        $partsWithoutSeconds[] = $sign . substr('0' . strval($hours), -2);
-        $partsWithoutSeconds[] = substr('0' . strval($minutes), -2);
+        $partsWithoutSeconds[] = $sign.substr('0'.strval($hours), -2);
+        $partsWithoutSeconds[] = substr('0'.strval($minutes), -2);
         $partsMaybeWithSeconds = $partsWithoutSeconds;
         /* @TZWS
         if ($seconds > 0) {
@@ -1629,8 +1627,8 @@ class Calendar
         $seconds -= $hours * 3600;
         $minutes = intval(floor($seconds / 60));
         $seconds -= $minutes * 60;
-        $hours2 = $sign . substr('0' . strval($hours), -2);
-        $minutes2 = substr('0' . strval($minutes), -2);
+        $hours2 = $sign.substr('0'.strval($hours), -2);
+        $minutes2 = substr('0'.strval($minutes), -2);
         /* @TZWS
         $seconds2 = substr('0' . strval($seconds), -2);
         */
@@ -1673,11 +1671,20 @@ class Calendar
     }
 
     /** @todo */
-    protected static function decodeWeekOfMonth(\DateTime $value, $count, $locale) { throw new Exception\NotImplemented(__METHOD__); }
+    protected static function decodeWeekOfMonth(\DateTime $value, $count, $locale)
+    {
+        throw new Exception\NotImplemented(__METHOD__);
+    }
     /** @todo */
-    protected static function decodeYearCyclicName() { throw new Exception\NotImplemented(__METHOD__); }
+    protected static function decodeYearCyclicName()
+    {
+        throw new Exception\NotImplemented(__METHOD__);
+    }
     /** @todo */
-    protected static function decodeModifiedGiulianDay() { throw new Exception\NotImplemented(__METHOD__); }
+    protected static function decodeModifiedGiulianDay()
+    {
+        throw new Exception\NotImplemented(__METHOD__);
+    }
 
     protected static function getTimezonesAliases($phpTimezoneName)
     {

--- a/code/Currency.php
+++ b/code/Currency.php
@@ -8,10 +8,10 @@ class Currency
 {
     /**
      * Returns all the currencies
-     * @param bool $alsoUnused=false Set to true to receive also currencies not currently used by any country, false otherwise
-     * @param bool $alsoNotTender=false Set to true to receive also currencies that aren't legal tender in any country
-     * @param string $locale='' The locale to use. If empty we'll use the default locale set with {@link \Punic\Data::setDefaultLocale()}.
-     * @return array Array keys are the currency code, array values are the currency name. It's sorted by currency values
+     * @param  bool   $alsoUnused=false    Set to true to receive also currencies not currently used by any country, false otherwise
+     * @param  bool   $alsoNotTender=false Set to true to receive also currencies that aren't legal tender in any country
+     * @param  string $locale=''           The locale to use. If empty we'll use the default locale set with {@link \Punic\Data::setDefaultLocale()}.
+     * @return array  Array keys are the currency code, array values are the currency name. It's sorted by currency values
      */
     public static function getAllCurrencies($alsoUnused = false, $alsoNotTender = false, $locale = '')
     {
@@ -56,14 +56,14 @@ class Currency
 
     /**
      * Returns the name of a currency given its code.
-     * @param string $currencyCode The currency code
+     * @param  string $currencyCode The currency code
      * @param null|number|string=null The quantity identifier. Allowed values:
-     * <ul>
-     *     <li>`null` to return the standard name, not associated to any quantity</li>
-     *     <li>`number` to return the name following the plural rule for the specified quantity</li>
-     *     <li>string `'zero'|'one'|'two'|'few'|'many'|'other'` the plural rule
-     * </ul>
-     * @param string $locale='' The locale to use. If empty we'll use the default locale set with {@link \Punic\Data::setDefaultLocale()}.
+     *                              <ul>
+     *                              <li>`null` to return the standard name, not associated to any quantity</li>
+     *                              <li>`number` to return the name following the plural rule for the specified quantity</li>
+     *                              <li>string `'zero'|'one'|'two'|'few'|'many'|'other'` the plural rule
+     *                              </ul>
+     * @param  string $locale=''    The locale to use. If empty we'll use the default locale set with {@link \Punic\Data::setDefaultLocale()}.
      * @return string Returns an empty string if $currencyCode is not valid, the localized currency name otherwise
      */
     public static function getName($currencyCode, $quantity = null, $locale = '')
@@ -90,9 +90,9 @@ class Currency
 
     /**
      * Returns the name of a currency given its code.
-     * @param string $currencyCode The currency code
-     * @param string $which='' Which symbol flavor do you prefer? 'narrow' for narrow symbols, 'alt' for alternative. Other values: standard/default symbol
-     * @param string $locale='' The locale to use. If empty we'll use the default locale set with {@link \Punic\Data::setDefaultLocale()}.
+     * @param  string $currencyCode The currency code
+     * @param  string $which=''     Which symbol flavor do you prefer? 'narrow' for narrow symbols, 'alt' for alternative. Other values: standard/default symbol
+     * @param  string $locale=''    The locale to use. If empty we'll use the default locale set with {@link \Punic\Data::setDefaultLocale()}.
      * @return string Returns an empty string if $currencyCode is not valid, the localized currency name otherwise
      */
     public static function getSymbol($currencyCode, $which = '', $locale = '')
@@ -128,14 +128,14 @@ class Currency
 
     /**
      * Return the history for the currencies used in a territory
-     * @param string $territoryCode The territoy code
-     * @return array Return a list of items with these keys:
-     * <ul>
-     *     <li>string `currency`: the currency code (always present)</li>
-     *     <li>string `from`: start date of the currency validity in the territory (not present if no start date) - Format is YYYY-MM-DD</li>
-     *     <li>string `to`: end date of the currency validity in the territory (not present if no end date) - Format is YYYY-MM-DD</li>
-     *     <li>bool `tender`: true if the currency was or is legal tender, false otherwise (always present)</li>
-     * </ul>
+     * @param  string $territoryCode The territoy code
+     * @return array  Return a list of items with these keys:
+     *                              <ul>
+     *                              <li>string `currency`: the currency code (always present)</li>
+     *                              <li>string `from`: start date of the currency validity in the territory (not present if no start date) - Format is YYYY-MM-DD</li>
+     *                              <li>string `to`: end date of the currency validity in the territory (not present if no end date) - Format is YYYY-MM-DD</li>
+     *                              <li>bool `tender`: true if the currency was or is legal tender, false otherwise (always present)</li>
+     *                              </ul>
      */
     public static function getCurrencyHistoryForTerritory($territoryCode)
     {
@@ -160,7 +160,7 @@ class Currency
 
     /**
      * Return the currency to be used in a territory
-     * @param string $territoryCode The territoy code
+     * @param  string $territoryCode The territoy code
      * @return string Returns an empty string if $territoryCode is not valid or we don't have info about it, the currency code otherwise
      */
     public static function getCurrencyForTerritory($territoryCode)

--- a/code/Data.php
+++ b/code/Data.php
@@ -52,7 +52,7 @@ class Data
 
     /**
      * Set the current default locale and language
-     * @param string $locale
+     * @param  string                         $locale
      * @throws \Punic\Exception\InvalidLocale Throws an exception if $locale is not a valid string
      */
     public static function setDefaultLocale($locale)
@@ -85,7 +85,7 @@ class Data
 
     /**
      * Set the current fallback locale and language
-     * @param string $locale
+     * @param  string                         $locale
      * @throws \Punic\Exception\InvalidLocale Throws an exception if $locale is not a valid string
      */
     public static function setFallbackLocale($locale)
@@ -101,8 +101,8 @@ class Data
 
     /**
      * Get the locale data
-     * @param string $identifier The data identifier
-     * @param string $locale='' The locale identifier (if empty we'll use the current default locale)
+     * @param  string           $identifier The data identifier
+     * @param  string           $locale=''  The locale identifier (if empty we'll use the current default locale)
      * @return array
      * @throws \Punic\Exception Throws an exception in case of problems
      * @internal
@@ -126,11 +126,11 @@ class Data
             if (!strlen($dir)) {
                 throw new Exception\DataFolderNotFound($locale, static::$fallbackLocale);
             }
-            $file = $dir . DIRECTORY_SEPARATOR . $identifier . '.json';
-            if (!is_file(__DIR__ . DIRECTORY_SEPARATOR . $file)) {
+            $file = $dir.DIRECTORY_SEPARATOR.$identifier.'.json';
+            if (!is_file(__DIR__.DIRECTORY_SEPARATOR.$file)) {
                 throw new Exception\DataFileNotFound($identifier, $locale, static::$fallbackLocale);
             }
-            $json = @file_get_contents(__DIR__ . DIRECTORY_SEPARATOR . $file);
+            $json = @file_get_contents(__DIR__.DIRECTORY_SEPARATOR.$file);
             //@codeCoverageIgnoreStart
             // In test enviro we can't replicate this problem
             if ($json === false) {
@@ -152,7 +152,7 @@ class Data
 
     /**
      * Get the generic data
-     * @param string $identifier The data identifier
+     * @param  string    $identifier The data identifier
      * @return array
      * @throws Exception Throws an exception in case of problems
      * @internal
@@ -168,11 +168,11 @@ class Data
         if (!preg_match('/^[a-zA-Z0-1_\\-]+$/', $identifier)) {
             throw new Exception\InvalidDataFile($identifier);
         }
-        $file = 'data' . DIRECTORY_SEPARATOR . "$identifier.json";
-        if (!is_file(__DIR__ . DIRECTORY_SEPARATOR . $file)) {
+        $file = 'data'.DIRECTORY_SEPARATOR."$identifier.json";
+        if (!is_file(__DIR__.DIRECTORY_SEPARATOR.$file)) {
             throw new Exception\DataFileNotFound($identifier);
         }
-        $json = @file_get_contents(__DIR__ . DIRECTORY_SEPARATOR . $file);
+        $json = @file_get_contents(__DIR__.DIRECTORY_SEPARATOR.$file);
         //@codeCoverageIgnoreStart
         // In test enviro we can't replicate this problem
         if ($json === false) {
@@ -193,18 +193,18 @@ class Data
 
     /**
      * Return a list of available locale identifiers
-     * @param bool $allowGroups=false Set to true if you want to retrieve locale groups (eg. 'en-001'), false otherwise
+     * @param  bool  $allowGroups=false Set to true if you want to retrieve locale groups (eg. 'en-001'), false otherwise
      * @return array
      */
     public static function getAvailableLocales($allowGroups = false)
     {
         $locales = array();
-        $dir = __DIR__ . DIRECTORY_SEPARATOR . 'data';
+        $dir = __DIR__.DIRECTORY_SEPARATOR.'data';
         if (is_dir($dir) && is_readable($dir)) {
             $contents = @scandir($dir);
             if (is_array($contents)) {
                 foreach (array_diff($contents, array('.', '..')) as $item) {
-                    if (is_dir($dir . DIRECTORY_SEPARATOR . $item)) {
+                    if (is_dir($dir.DIRECTORY_SEPARATOR.$item)) {
                         if ($item === 'root') {
                             $item = 'en-US';
                         }
@@ -233,8 +233,8 @@ class Data
 
     /**
      * Try to guess the full locale (with script and territory) ID associated to a language
-     * @param string $language='' The language identifier (if empty we'll use the current default language)
-     * @param string $script='' The script identifier (if $language is empty we'll use the current default script)
+     * @param  string $language='' The language identifier (if empty we'll use the current default language)
+     * @param  string $script=''   The script identifier (if $language is empty we'll use the current default script)
      * @return string Returns an empty string if the territory was not found, the territory ID otherwise
      */
     public static function guessFullLocale($language = '', $script = '')
@@ -269,8 +269,8 @@ class Data
 
     /**
      * Return the terrotory associated to the locale (guess it if it's not present in $locale)
-     * @param string $locale='' The locale identifier (if empty we'll use the current default locale)
-     * @param bool $checkFallbackLocale=true Set to true to check the fallback locale if $locale (or the default locale) don't have an associated territory, false to don't fallback to fallback locale
+     * @param  string $locale=''                The locale identifier (if empty we'll use the current default locale)
+     * @param  bool   $checkFallbackLocale=true Set to true to check the fallback locale if $locale (or the default locale) don't have an associated territory, false to don't fallback to fallback locale
      * @return string
      */
     public static function getTerritory($locale = '', $checkFallbackLocale = true)
@@ -315,9 +315,9 @@ class Data
 
     /**
      * Return the node associated to the locale territory
-     * @param array $data The parent array for which you want the territory node
-     * @param string $locale='' The locale identifier (if empty we'll use the current default locale)
-     * @return mixed Returns null if the node was not found, the node data otherwise
+     * @param  array  $data      The parent array for which you want the territory node
+     * @param  string $locale='' The locale identifier (if empty we'll use the current default locale)
+     * @return mixed  Returns null if the node was not found, the node data otherwise
      * @internal
      */
     public static function getTerritoryNode($data, $locale = '')
@@ -337,9 +337,9 @@ class Data
 
     /**
      * Return the node associated to the language (not locale) territory
-     * @param array $data The parent array for which you want the language node
-     * @param string $locale='' The locale identifier (if empty we'll use the current default locale)
-     * @return mixed Returns null if the node was not found, the node data otherwise
+     * @param  array  $data      The parent array for which you want the language node
+     * @param  string $locale='' The locale identifier (if empty we'll use the current default locale)
+     * @return mixed  Returns null if the node was not found, the node data otherwise
      * @internal
      */
     public static function getLanguageNode($data, $locale = '')
@@ -360,9 +360,9 @@ class Data
 
     /**
      * Returns the item of an array associated to a locale
-     * @param array $data The data containing the locale info
-     * @param string $locale='' The locale identifier (if empty we'll use the current default locale)
-     * @return mixed Returns null if $data is not an array or it does not contain locale info, the array item otherwise
+     * @param  array  $data      The data containing the locale info
+     * @param  string $locale='' The locale identifier (if empty we'll use the current default locale)
+     * @return mixed  Returns null if $data is not an array or it does not contain locale info, the array item otherwise
      * @internal
      */
     public static function getLocaleItem($data, $locale = '')
@@ -385,7 +385,7 @@ class Data
 
     /**
      * Parse a string representing a locale and extract its components.
-     * @param string $locale
+     * @param  string        $locale
      * @return null]string[] Return null if $locale is not valid; if $locale is valid returns an array with keys 'language', 'script', 'territory'
      * @internal
      */
@@ -449,7 +449,7 @@ class Data
 
     /**
      * Returns the path of the locale-specific data, looking also for the fallback locale
-     * @param string $locale The locale for which you want the data folder
+     * @param  string $locale The locale for which you want the data folder
      * @return string Returns an empty string if the folder is not found, the absolute path to the folder otherwise
      */
     protected static function getLocaleFolder($locale)
@@ -457,11 +457,11 @@ class Data
         static $cache = array();
         $result = '';
         if (is_string($locale)) {
-            $key = $locale . '/' . static::$fallbackLocale;
+            $key = $locale.'/'.static::$fallbackLocale;
             if (!isset($cache[$key])) {
                 foreach (static::getLocaleAlternatives($locale) as $alternative) {
-                    $dir = 'data' . DIRECTORY_SEPARATOR . $alternative;
-                    if (is_dir(__DIR__ . DIRECTORY_SEPARATOR . $dir)) {
+                    $dir = 'data'.DIRECTORY_SEPARATOR.$alternative;
+                    if (is_dir(__DIR__.DIRECTORY_SEPARATOR.$dir)) {
                         $result = $dir;
                         break;
                     }
@@ -476,8 +476,8 @@ class Data
 
     /**
      * Returns a list of locale identifiers associated to a locale
-     * @param string $locale The locale for which you want the alternatives
-     * @param string $addFallback=true Set to true to add the fallback locale to the result, false otherwise
+     * @param  string $locale           The locale for which you want the alternatives
+     * @param  string $addFallback=true Set to true to add the fallback locale to the result, false otherwise
      * @return array
      */
     protected static function getLocaleAlternatives($locale, $addFallback = true)

--- a/code/Exception.php
+++ b/code/Exception.php
@@ -62,8 +62,8 @@ class Exception extends \Exception
 
     /**
      * Initializes the instance
-     * @param string $message The exception message
-     * @param int $code=null The exception code
+     * @param string     $message       The exception message
+     * @param int        $code=null     The exception code
      * @param \Exception $previous=null The previous exception used for the exception chaining
      */
     public function __construct($message, $code = null, $previous = null)

--- a/code/Exception/BadArgumentType.php
+++ b/code/Exception/BadArgumentType.php
@@ -11,9 +11,9 @@ class BadArgumentType extends \Punic\Exception
     protected $destinationTypeDescription;
     /**
      * Initializes the instance
-     * @param mixed $argumentValue The value of the invalid argument
-     * @param string $destinationTypeDescription The description of the destination type
-     * @param \Exception $previous=null The previous exception used for the exception chaining
+     * @param mixed      $argumentValue              The value of the invalid argument
+     * @param string     $destinationTypeDescription The description of the destination type
+     * @param \Exception $previous=null              The previous exception used for the exception chaining
      */
     public function __construct($argumentValue, $destinationTypeDescription, $previous = null)
     {

--- a/code/Exception/BadDataFileContents.php
+++ b/code/Exception/BadDataFileContents.php
@@ -12,9 +12,9 @@ class BadDataFileContents extends \Punic\Exception
 
     /**
      * Initializes the instance
-     * @param string $dataFilePath The path to the file with bad contents
-     * @param string $dataFileContents The malformed of the file
-     * @param \Exception $previous=null The previous exception used for the exception chaining
+     * @param string     $dataFilePath     The path to the file with bad contents
+     * @param string     $dataFileContents The malformed of the file
+     * @param \Exception $previous=null    The previous exception used for the exception chaining
      */
     public function __construct($dataFilePath, $dataFileContents, $previous = null)
     {

--- a/code/Exception/DataFileNotFound.php
+++ b/code/Exception/DataFileNotFound.php
@@ -12,10 +12,10 @@ class DataFileNotFound extends \Punic\Exception
 
     /**
      * Initializes the instance
-     * @param string $identifier The data file identifier
-     * @param string $locale='' The preferred locale (if the data file is locale-specific)
-     * @param string $fallbackLocale='' The fallback locale (if the data file is locale-specific)
-     * @param \Exception $previous=null The previous exception used for the exception chaining
+     * @param string     $identifier        The data file identifier
+     * @param string     $locale=''         The preferred locale (if the data file is locale-specific)
+     * @param string     $fallbackLocale='' The fallback locale (if the data file is locale-specific)
+     * @param \Exception $previous=null     The previous exception used for the exception chaining
      */
     public function __construct($identifier, $locale = '', $fallbackLocale = '', $previous = null)
     {

--- a/code/Exception/DataFileNotReadable.php
+++ b/code/Exception/DataFileNotReadable.php
@@ -10,7 +10,7 @@ class DataFileNotReadable extends \Punic\Exception
 
     /**
      * Initializes the instance
-     * @param string $dataFilePath The path to the unreadable file
+     * @param string     $dataFilePath  The path to the unreadable file
      * @param \Exception $previous=null The previous exception used for the exception chaining
      */
     public function __construct($dataFilePath, $previous = null)
@@ -28,5 +28,4 @@ class DataFileNotReadable extends \Punic\Exception
     {
         return $this->dataFilePath;
     }
-
 }

--- a/code/Exception/DataFolderNotFound.php
+++ b/code/Exception/DataFolderNotFound.php
@@ -11,9 +11,9 @@ class DataFolderNotFound extends \Punic\Exception
 
     /**
      * Initializes the instance
-     * @param string $locale The preferred locale
-     * @param string $fallbackLocale The fallback locale
-     * @param \Exception $previous=null The previous exception used for the exception chaining
+     * @param string     $locale         The preferred locale
+     * @param string     $fallbackLocale The fallback locale
+     * @param \Exception $previous=null  The previous exception used for the exception chaining
      */
     public function __construct($locale, $fallbackLocale, $previous = null)
     {

--- a/code/Exception/InvalidDataFile.php
+++ b/code/Exception/InvalidDataFile.php
@@ -11,7 +11,7 @@ class InvalidDataFile extends \Punic\Exception
 
     /**
      * Initializes the instance
-     * @param mixed $identifier The bad data file identifier
+     * @param mixed      $identifier    The bad data file identifier
      * @param \Exception $previous=null The previous exception used for the exception chaining
      */
     public function __construct($identifier, $previous = null)

--- a/code/Exception/InvalidLocale.php
+++ b/code/Exception/InvalidLocale.php
@@ -10,7 +10,7 @@ class InvalidLocale extends \Punic\Exception
 
     /**
      * Initializes the instance
-     * @param mixed $locale The bad locale
+     * @param mixed      $locale        The bad locale
      * @param \Exception $previous=null The previous exception used for the exception chaining
      */
     public function __construct($locale, $previous = null)

--- a/code/Exception/NotImplemented.php
+++ b/code/Exception/NotImplemented.php
@@ -9,7 +9,7 @@ class NotImplemented extends \Punic\Exception
     protected $function;
     /**
      * Initializes the instance
-     * @param string $function The function/method that's not implemented
+     * @param string     $function      The function/method that's not implemented
      * @param \Exception $previous=null The previous exception used for the exception chaining
      */
     public function __construct($function, $previous = null)

--- a/code/Exception/ValueNotInList.php
+++ b/code/Exception/ValueNotInList.php
@@ -11,15 +11,15 @@ class ValueNotInList extends \Punic\Exception
     protected $allowedValues;
     /**
      * Initializes the instance
-     * @param string|numeric $value The invalid value
+     * @param string|numeric        $value         The invalid value
      * @param array[string|numeric] $allowedValues The list of valid values
-     * @param \Exception $previous=null The previous exception used for the exception chaining
+     * @param \Exception            $previous=null The previous exception used for the exception chaining
      */
     public function __construct($value, $allowedValues, $previous = null)
     {
         $this->value = $value;
         $this->allowedValues = $allowedValues;
-        $message = "'$value' is not valid. Acceptable values are: '" . implode("', '", $allowedValues) . "'";
+        $message = "'$value' is not valid. Acceptable values are: '".implode("', '", $allowedValues)."'";
         parent::__construct($message, \Punic\Exception::VALUE_NOT_IN_LIST, $previous);
     }
 

--- a/code/Language.php
+++ b/code/Language.php
@@ -8,10 +8,10 @@ class Language
 {
     /**
      * Return all the languages
-     * @param bool $excludeCountrySpecific=false Set to false (default) to include also Country-specific languages (eg 'U.S. English' in addition to 'English'), set to true to exclude them
-     * @param bool $excludeScriptSpecific=false Set to false (default) to include also script-specific languages (eg 'Simplified Chinese' in addition to 'Chinese'), set to true to exclude them
-     * @param string $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
-     * @return array Return an array, sorted by values, whose keys are the language IDs and the values are the localized language names
+     * @param  bool   $excludeCountrySpecific=false Set to false (default) to include also Country-specific languages (eg 'U.S. English' in addition to 'English'), set to true to exclude them
+     * @param  bool   $excludeScriptSpecific=false  Set to false (default) to include also script-specific languages (eg 'Simplified Chinese' in addition to 'Chinese'), set to true to exclude them
+     * @param  string $locale=''                    The locale to use. If empty we'll use the default locale set in \Punic\Data
+     * @return array  Return an array, sorted by values, whose keys are the language IDs and the values are the localized language names
      */
     public static function getAll($excludeCountrySpecific = false, $excludeScriptSpecific = false, $locale = '')
     {
@@ -44,8 +44,8 @@ class Language
 
     /**
      * Retrieve the name of a language
-     * @param string $languageCode The language code. If it contails also a terrotory code (eg: 'en-US'), the result will contain also the territory code (eg 'English (United States)')
-     * @param string $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
+     * @param  string $languageCode The language code. If it contails also a terrotory code (eg: 'en-US'), the result will contain also the territory code (eg 'English (United States)')
+     * @param  string $locale=''    The locale to use. If empty we'll use the default locale set in \Punic\Data
      * @return string Returns the localized language name (returns $languageCode if not found)
      */
     public static function getName($languageCode, $locale = '')

--- a/code/Misc.php
+++ b/code/Misc.php
@@ -8,20 +8,20 @@ class Misc
 {
     /**
      * Concatenates a list of items returning a localized string (for instance: array(1, 2, 3) will result in '1, 2, and 3' for English or '1, 2 e 3' for Italian)
-     * @param array $list The list to concatenate
-     * @param string $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
+     * @param  array  $list      The list to concatenate
+     * @param  string $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
      * @return string Returns an empty string if $list is not an array of it it's empty, the joined items otherwise.
      */
-    public static function join($list, $locale = '')
+    public static function implode($list, $locale = '')
     {
         return static::joinInternal($list, null, $locale);
     }
 
     /**
      * Concatenates a list of unit items returning a localized string (for instance: array('3 ft', '2 in') will result in '3 ft, 2 in'
-     * @param array $list The list to concatenate
-     * @param string $width='' The preferred width ('' for default, or 'short' or 'narrow')
-     * @param string $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
+     * @param  array  $list      The list to concatenate
+     * @param  string $width=''  The preferred width ('' for default, or 'short' or 'narrow')
+     * @param  string $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
      * @return string Returns an empty string if $list is not an array of it it's empty, the joined items otherwise.
      */
     public static function joinUnits($list, $width = '', $locale = '')
@@ -90,12 +90,12 @@ class Misc
 
     /**
      * Fix the case of a string.
-     * @param string $string The string whose case needs to be fixed
-     * @param string $case How to fix case. Allowed values:
-     *   <li>`'titlecase-words'` all words in the phrase should be title case</li>
-     *   <li>`'titlecase-firstword'` the first word should be title case</li>
-     *   <li>`'lowercase-words'` all words in the phrase should be lower case</li>
-     * </ul>
+     * @param  string $string The string whose case needs to be fixed
+     * @param  string $case   How to fix case. Allowed values:
+     *                        <li>`'titlecase-words'` all words in the phrase should be title case</li>
+     *                        <li>`'titlecase-firstword'` the first word should be title case</li>
+     *                        <li>`'lowercase-words'` all words in the phrase should be lower case</li>
+     *                        </ul>
      * @return string
      * @link http://cldr.unicode.org/development/development-process/design-proposals/consistent-casing
      */
@@ -112,7 +112,7 @@ class Misc
                             if ($l === 1) {
                                 $s = mb_strtoupper($s, 'UTF-8');
                             } else {
-                                $s = mb_strtoupper(mb_substr($s, 0, 1, 'UTF-8'), 'UTF-8') . mb_substr($s, 1, $l - 1, 'UTF-8');
+                                $s = mb_strtoupper(mb_substr($s, 0, 1, 'UTF-8'), 'UTF-8').mb_substr($s, 1, $l - 1, 'UTF-8');
                             }
 
                             return $s;
@@ -125,7 +125,7 @@ class Misc
                         if ($l === 1) {
                             $result = mb_strtoupper($string, 'UTF-8');
                         } elseif ($l > 1) {
-                            $result = mb_strtoupper(mb_substr($string, 0, 1, 'UTF-8'), 'UTF-8') . mb_substr($string, 1, $l - 1, 'UTF-8');
+                            $result = mb_strtoupper(mb_substr($string, 0, 1, 'UTF-8'), 'UTF-8').mb_substr($string, 1, $l - 1, 'UTF-8');
                         }
                     }
                     break;
@@ -142,8 +142,8 @@ class Misc
 
     /**
      * Parse the browser HTTP_ACCEPT_LANGUAGE header and return the found locales, sorted in descending order by the quality values
-     * @param boolean $ignoreCache=false Set to true if you want to ignore the cache
-     * @return array Array keys are the found locales, array values are the relative quality value (from 0 to 1)
+     * @param  boolean $ignoreCache=false Set to true if you want to ignore the cache
+     * @return array   Array keys are the found locales, array values are the relative quality value (from 0 to 1)
      */
     public static function getBrowserLocales($ignoreCache = false)
     {
@@ -163,8 +163,8 @@ class Misc
 
     /**
      * Parse the value of an HTTP_ACCEPT_LANGUAGE header and return the found locales, sorted in descending order by the quality values
-     * @param string $httpAcceptLanguages
-     * @return array Array keys are the found locales, array values are the relative quality value (from 0 to 1)
+     * @param  string $httpAcceptLanguages
+     * @return array  Array keys are the found locales, array values are the relative quality value (from 0 to 1)
      */
     public static function parseHttpAcceptLanguage($httpAcceptLanguages)
     {
@@ -174,7 +174,7 @@ class Misc
                 if (preg_match('/^([a-z]{2,3}(?:[_\\-][a-z]+)*)(?:\\s*;(?:\\s*q(?:\\s*=(?:\\s*([\\d.]+))?)?)?)?$/', strtolower(trim($httpAcceptLanguage, " \t")), $m)) {
                     if (count($m) > 2) {
                         if (strpos($m[2], '.') === 0) {
-                            $m[2] = '0' . $m[2];
+                            $m[2] = '0'.$m[2];
                         }
                         if (preg_match('/^[01](\\.\\d*)?$/', $m[2])) {
                             $quality = round(@floatval($m[2]), 4);
@@ -194,15 +194,15 @@ class Misc
                             $base = $chunks[0];
                             for ($i = 1; $i < $numChunks; $i++) {
                                 if (strlen($chunks[$i]) === 4) {
-                                    $base .= '-' . ucfirst($chunks[$i]);
+                                    $base .= '-'.ucfirst($chunks[$i]);
                                     break;
                                 }
                             }
                             for ($i = 1; $i < $numChunks; $i++) {
                                 if (preg_match('/^[a-z][a-z]$/', $chunks[$i])) {
-                                    $found[] = $base . '-' . strtoupper($chunks[$i]);
+                                    $found[] = $base.'-'.strtoupper($chunks[$i]);
                                 } elseif (preg_match('/^\\d{3}$/', $chunks[$i])) {
-                                    $found[] = $base . '-' . $chunks[$i];
+                                    $found[] = $base.'-'.$chunks[$i];
                                 }
                             }
                             if (empty($found)) {
@@ -229,7 +229,7 @@ class Misc
 
     /**
      * Retrieve the character order (right-to-left or left-to-right)
-     * @param string $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
+     * @param  string $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
      * @return string Return 'left-to-right' or 'right-to-left'
      */
     public static function getCharacterOrder($locale = '')
@@ -241,7 +241,7 @@ class Misc
 
     /**
      * Retrieve the line order (top-to-bottom or bottom-to-top)
-     * @param string $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
+     * @param  string $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
      * @return string Return 'top-to-bottom' or 'bottom-to-top'
      */
     public static function getLineOrder($locale = '')

--- a/code/Number.php
+++ b/code/Number.php
@@ -6,11 +6,10 @@ namespace Punic;
  */
 class Number
 {
-
     /**
      * Check if a variable contains a valid number for the specified locale
-     * @param string $value The string value to check
-     * @param string $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
+     * @param  string $value     The string value to check
+     * @param  string $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
      * @return bool
      */
     public static function isNumeric($value, $locale = '')
@@ -20,8 +19,8 @@ class Number
 
     /**
      * Check if a variable contains a valid integer number for the specified locale
-     * @param string $value The string value to check
-     * @param string $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
+     * @param  string $value     The string value to check
+     * @param  string $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
      * @return bool
      */
     public static function isInteger($value, $locale = '')
@@ -41,10 +40,10 @@ class Number
 
     /**
      * Localize a number representation (for instance, converts 1234.5 to '1,234.5' in case of English and to '1.234,5' in case of Italian)
-     * @param numeric $value The string value to convert
-     * @param int|null $precision=null The wanted precision (well use {@link http://php.net/manual/function.round.php})
-     * @param string $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
-     * @return string Returns an empty string $value is not a number, otherwise returns the localized representation of the number
+     * @param  numeric  $value          The string value to convert
+     * @param  int|null $precision=null The wanted precision (well use {@link http://php.net/manual/function.round.php})
+     * @param  string   $locale=''      The locale to use. If empty we'll use the default locale set in \Punic\Data
+     * @return string   Returns an empty string $value is not a number, otherwise returns the localized representation of the number
      */
     public static function format($value, $precision = null, $locale = '')
     {
@@ -92,17 +91,16 @@ class Number
                 $groupSign = $data['symbols']['group'];
                 $preLength = 1 + (($len -1) % 3);
                 $pre = substr($intPart, 0, $preLength);
-                $intPart = $pre . $groupSign . implode($groupSign, str_split(substr($intPart, $preLength), $groupLength));
+                $intPart = $pre.$groupSign.implode($groupSign, str_split(substr($intPart, $preLength), $groupLength));
             }
-            $result = $sign . $intPart;
+            $result = $sign.$intPart;
             if (is_null($precision)) {
                 if (strlen($floatPath)) {
-                    $result .= $decimal . $floatPath;
+                    $result .= $decimal.$floatPath;
                 }
             } elseif ($precision > 0) {
-                $result .= $decimal . substr(str_pad($floatPath, $precision, '0', STR_PAD_RIGHT), 0, $precision);
+                $result .= $decimal.substr(str_pad($floatPath, $precision, '0', STR_PAD_RIGHT), 0, $precision);
             }
-
         }
 
         return $result;
@@ -110,8 +108,8 @@ class Number
 
     /**
      * Convert a localized representation of a number to a number (for instance, converts the string '1,234' to 1234 in case of English and to 1.234 in case of Italian)
-     * @param string $value The string value to convert
-     * @param string $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
+     * @param  string         $value     The string value to convert
+     * @param  string         $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
      * @return int|float|null Returns null if $value is not valid, the numeric value otherwise
      */
     public static function unformat($value, $locale = '')
@@ -130,19 +128,19 @@ class Number
             $group = $data['symbols']['group'];
             $groupQ = preg_quote($group);
             $ok = true;
-            if (preg_match('/^' . "($plusQ|$minusQ)?(\\d+(?:$groupQ\\d+)*)" . '$/', $value, $m)) {
+            if (preg_match('/^'."($plusQ|$minusQ)?(\\d+(?:$groupQ\\d+)*)".'$/', $value, $m)) {
                 $sign = $m[1];
                 $int = $m[2];
                 $float = null;
-            } elseif (preg_match('/^' . "($plusQ|$minusQ)?(\\d+(?:$groupQ\\d+)*)$decimalQ" . '$/', $value, $m)) {
+            } elseif (preg_match('/^'."($plusQ|$minusQ)?(\\d+(?:$groupQ\\d+)*)$decimalQ".'$/', $value, $m)) {
                 $sign = $m[1];
                 $int = $m[2];
                 $float = '';
-            } elseif (preg_match('/^' . "($plusQ|$minusQ)?(\\d+(?:$groupQ\\d+)*)$decimalQ(\\d+)" . '$/', $value, $m)) {
+            } elseif (preg_match('/^'."($plusQ|$minusQ)?(\\d+(?:$groupQ\\d+)*)$decimalQ(\\d+)".'$/', $value, $m)) {
                 $sign = $m[1];
                 $int = $m[2];
                 $float = $m[3];
-            } elseif (preg_match('/^' . "($plusQ|$minusQ)?$decimalQ(\\d+)" . '$/', $value, $m)) {
+            } elseif (preg_match('/^'."($plusQ|$minusQ)?$decimalQ(\\d+)".'$/', $value, $m)) {
                 $sign = $m[1];
                 $int = '0';
                 $float = $m[2];

--- a/code/Phone.php
+++ b/code/Phone.php
@@ -8,8 +8,8 @@ class Phone
 {
     /**
      * Retrieve the list of the country calling codes for a specific country
-     * @param string $territoryCode The country identifier ('001' for global systems, for instance satellite communications like Iridium)
-     * @return array Returns the list of country calling codes found for the specified country (eg: for 'US' you'll get array('1'))
+     * @param  string $territoryCode The country identifier ('001' for global systems, for instance satellite communications like Iridium)
+     * @return array  Returns the list of country calling codes found for the specified country (eg: for 'US' you'll get array('1'))
      */
     public static function getPrefixesForTerritory($territoryCode)
     {
@@ -27,8 +27,8 @@ class Phone
 
     /**
      * Retrieve the list of territory codes for a specific prefix
-     * @param string $prefix The country calling code (for instance: '1')
-     * @return array Returns the list of territories for which the specified prefix is applicable (eg: for '1' you'll get array('US', 'AG', 'AI', 'CA', ...))
+     * @param  string $prefix The country calling code (for instance: '1')
+     * @return array  Returns the list of territories for which the specified prefix is applicable (eg: for '1' you'll get array('US', 'AG', 'AI', 'CA', ...))
      */
     public static function getTerritoriesForPrefix($prefix)
     {

--- a/code/Plural.php
+++ b/code/Plural.php
@@ -6,10 +6,9 @@ namespace Punic;
  */
 class Plural
 {
-
     /**
      * Return the list of applicable plural rule for a locale
-     * @param string $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
+     * @param  string        $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
      * @return array[string] Returns a list containing some the following values: 'zero', 'one', 'two', 'few', 'many', 'other' ('other' will be always there)
      */
     public static function getRules($locale = '')
@@ -24,11 +23,11 @@ class Plural
 
     /**
      * Return the plural rule ('zero', 'one', 'two', 'few', 'many' or 'other') for a number and a locale
-     * @param string|int|float $number The number to check the plural rule for for
-     * @param string $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
-     * @return string Returns one of the following values: 'zero', 'one', 'two', 'few', 'many', 'other'
+     * @param  string|int|float                 $number    The number to check the plural rule for for
+     * @param  string                           $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
+     * @return string                           Returns one of the following values: 'zero', 'one', 'two', 'few', 'many', 'other'
      * @throws \Punic\Exception\BadArgumentType Throws a \Punic\Exception\BadArgumentType if $number is not a valid number
-     * @throws \Exception Throws a \Exception if there were problems calculating the plural rule
+     * @throws \Exception                       Throws a \Exception if there were problems calculating the plural rule
      */
     public static function getRule($number, $locale = '')
     {
@@ -60,7 +59,7 @@ class Plural
             throw new Exception\BadArgumentType($number, 'number');
         }
         // 'n' => '%1$s', // absolute value of the source number (integer and decimals).
-        $v1 = $intPartAbs . (strlen($floatPart) ? ".$floatPart" : '');
+        $v1 = $intPartAbs.(strlen($floatPart) ? ".$floatPart" : '');
         // 'i' => '%2$s', // integer digits of n
         $v2 = $intPartAbs;
         // 'v' => '%3$s', // number of visible fraction digits in n, with trailing zeros.
@@ -88,9 +87,9 @@ class Plural
                 $decimals = strlen(rtrim($decimalPart, '0'));
                 if ($decimals > 0) {
                     $pow = intval(pow(10, $decimals));
-                    $repl = '(' . strval(intval(floatval($m[1]) * $pow)) . ' % ' . strval(intval(floatval($m[2] * $pow))) . ') / ' . $pow;
+                    $repl = '('.strval(intval(floatval($m[1]) * $pow)).' % '.strval(intval(floatval($m[2] * $pow))).') / '.$pow;
                 } else {
-                    $repl = strval(intval($m[1])) . ' % ' . $m[2];
+                    $repl = strval(intval($m[1])).' % '.$m[2];
                 }
                 $formula = str_replace($m[0], $repl, $formula);
             }
@@ -99,7 +98,7 @@ class Plural
                 $result = $rule;
                 break;
             } elseif ($formulaResult !== 'no') {
-                throw new \Exception('There was a problem in the formula ' . $formulaPattern);
+                throw new \Exception('There was a problem in the formula '.$formulaPattern);
             }
         }
 
@@ -120,7 +119,6 @@ class Plural
         foreach ($rangeValues as $rangeValue) {
             if (is_array($rangeValue)) {
                 if ($isInt && ($value >= $rangeValue[0]) && ($value <= $rangeValue[1])) {
-
                     $included = true;
                     break;
                 }

--- a/code/Territory.php
+++ b/code/Territory.php
@@ -8,8 +8,8 @@ class Territory
 {
     /**
      * Retrieve the name of a territory (country, continent, ...)
-     * @param string $territoryCode The territory code
-     * @param string $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
+     * @param  string $territoryCode The territory code
+     * @param  string $locale=''     The locale to use. If empty we'll use the default locale set in \Punic\Data
      * @return string Returns the localized territory name (returns $territoryCode if not found)
      */
     public static function getName($territoryCode, $locale = '')
@@ -28,7 +28,7 @@ class Territory
 
     /**
      * Return the list of continents in the form of an array with key=ID, value=name
-     * @param string $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
+     * @param  string $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
      * @return array
      */
     public static function getContinents($locale = '')
@@ -38,7 +38,7 @@ class Territory
 
     /**
      * Return the list of countries in the form of an array with key=ID, value=name
-     * @param string $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
+     * @param  string $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
      * @return array
      */
     public static function getCountries($locale = '')
@@ -70,7 +70,7 @@ class Territory
      * }
      * ```
      * The arrays are sorted by territory name
-     * @param string $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
+     * @param  string $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
      * @return array
      */
     public static function getContinentsAndCountries($locale = '')
@@ -89,8 +89,8 @@ class Territory
      * </ul>
      * If only one level is specified you'll get a flat list (like the one returned by {@link getContinents}).
      * If one or more levels are specified, you'll get a structured list (like the one returned by {@link getContinentsAndCountries}).
-     * @param string $levels A string with one or more of the characters: 'W' (for world), 'C' (for continents), 'S' (for sub-continents), 'c' (for countries)
-     * @param string $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
+     * @param  string                    $levels    A string with one or more of the characters: 'W' (for world), 'C' (for continents), 'S' (for sub-continents), 'c' (for countries)
+     * @param  string                    $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
      * @return array
      * @link http://www.unicode.org/cldr/charts/latest/supplemental/territory_containment_un_m_49.html
      * @throws Exception\BadArgumentType
@@ -113,7 +113,7 @@ class Territory
             }
         }
         if (count($decodedLevels) === 0) {
-            throw new \Punic\Exception\BadArgumentType($levels, "list of territory kinds: it should be a list of one or more of the codes '" . implode("', '", array_keys($levelMap)) . "'");
+            throw new \Punic\Exception\BadArgumentType($levels, "list of territory kinds: it should be a list of one or more of the codes '".implode("', '", array_keys($levelMap))."'");
         }
         $struct = self::filterStructure(self::getStructure(), $decodedLevels, 0);
         $flatList = (count($decodedLevels) > 1) ? false : true;
@@ -139,23 +139,23 @@ class Territory
 
     /**
      * Return the list of languages spoken in a territory
-     * @param string $territoryCode The territory code
-     * @param string $filterStatuses='' Filter language status.
-     * <ul>
-     *     <li>If empty no filter will be applied</li>
-     *     <li>'o' to include official languages</li>
-     *     <li>'r' to include official regional languages</li>
-     *     <li>'f' to include de facto official languages</li>
-     *     <li>'m' to include official minority languages</li>
-     *     <li>'u' to include unofficial or unknown languages</li>
-     * </ul>
-     * @param string $onlyCodes=false Set to true to retrieve only the language codes. If set to false (default) you'll receive a list of arrays with these keys:
-     * <ul>
-     *     <li>string id: the language identifier</li>
-     *     <li>string status: 'o' for official; 'r' for official regional; 'f' for de facto official; 'm' for official minority; 'u' for unofficial or unknown</li>
-     *     <li>number population: the amount of people speaking the language (%)</li>
-     *     <li>number|null writing: the amount of people able to write (%). May be null if no data is available</li>
-     * </ul>
+     * @param  string     $territoryCode     The territory code
+     * @param  string     $filterStatuses='' Filter language status.
+     *                                       <ul>
+     *                                       <li>If empty no filter will be applied</li>
+     *                                       <li>'o' to include official languages</li>
+     *                                       <li>'r' to include official regional languages</li>
+     *                                       <li>'f' to include de facto official languages</li>
+     *                                       <li>'m' to include official minority languages</li>
+     *                                       <li>'u' to include unofficial or unknown languages</li>
+     *                                       </ul>
+     * @param  string     $onlyCodes=false   Set to true to retrieve only the language codes. If set to false (default) you'll receive a list of arrays with these keys:
+     *                                       <ul>
+     *                                       <li>string id: the language identifier</li>
+     *                                       <li>string status: 'o' for official; 'r' for official regional; 'f' for de facto official; 'm' for official minority; 'u' for unofficial or unknown</li>
+     *                                       <li>number population: the amount of people speaking the language (%)</li>
+     *                                       <li>number|null writing: the amount of people able to write (%). May be null if no data is available</li>
+     *                                       </ul>
      * @return array|null Return the languages spoken in the specified territory, as described by the $onlyCodes parameter (or null if $territoryCode is not valid or no data is available)
      */
     public static function getLanguages($territoryCode, $filterStatuses = '', $onlyCodes = false)
@@ -186,7 +186,7 @@ class Territory
 
     /**
      * Return the population of a specific territory
-     * @param string $territoryCode The territory code
+     * @param  string      $territoryCode The territory code
      * @return number|null Return the size of the population of the specified territory (or null if $territoryCode is not valid or no data is available)
      */
     public static function getPopulation($territoryCode)
@@ -202,7 +202,7 @@ class Territory
 
     /**
      * Return the literacy level for a specific territory, in %
-     * @param string $territoryCode The territory code
+     * @param  string      $territoryCode The territory code
      * @return number|null Return the % of literacy lever of the specified territory (or null if $territoryCode is not valid or no data is available)
      */
     public static function getLiteracyLevel($territoryCode)
@@ -218,7 +218,7 @@ class Territory
 
     /**
      * Return the GDP (Gross Domestic Product) for a specific territory, in US$
-     * @param string $territoryCode The territory code
+     * @param  string      $territoryCode The territory code
      * @return number|null Return the GDP of the specified territory (or null if $territoryCode is not valid or no data is available)
      */
     public static function getGrossDomesticProduct($territoryCode)
@@ -234,7 +234,7 @@ class Territory
 
     /**
      * Return a list of territory IDs where a specific language is spoken, sorted by the total number of people speaking that language.
-     * @param string $languageID The language identifier
+     * @param  string $languageID The language identifier
      * @return array
      */
     public static function getTerritoriesForLanguage($languageID)
@@ -242,7 +242,7 @@ class Territory
         $langPeople = array();
         foreach (Data::getGeneric('territoryInfo') as $territoryID => $territoryInfo) {
             foreach ($territoryInfo['languages'] as $langID => $langInfo) {
-                if ((strcasecmp($languageID, $langID) === 0) || (stripos($langID, $languageID . '_') === 0)) {
+                if ((strcasecmp($languageID, $langID) === 0) || (stripos($langID, $languageID.'_') === 0)) {
                     $langPeople[] = array('territoryID' => $territoryID, 'people' => $territoryInfo['population'] * $langInfo['population']);
                 }
             }
@@ -267,7 +267,7 @@ class Territory
 
     /**
      * Return the code of the territory that contains a territory
-     * @param string $childTerritoryCode
+     * @param  string $childTerritoryCode
      * @return string Return the parent territory code, or an empty string if $childTerritoryCode is the World (001) or if it's invalid.
      */
     public static function getParentTerritoryCode($childTerritoryCode)
@@ -277,7 +277,7 @@ class Territory
             $childTerritoryCode = strtoupper($childTerritoryCode);
             foreach (\Punic\Data::getGeneric('territoryContainment') as $parentTerritoryCode => $parentTerritoryInfo) {
                 if (in_array($childTerritoryCode, $parentTerritoryInfo['contains'], true)) {
-                    $result = is_int($parentTerritoryCode) ? substr('00' . $parentTerritoryCode, -3) : $parentTerritoryCode;
+                    $result = is_int($parentTerritoryCode) ? substr('00'.$parentTerritoryCode, -3) : $parentTerritoryCode;
                     if (($result === '001') || (strlen(static::getParentTerritoryCode($result)) > 0)) {
                         break;
                     }
@@ -290,9 +290,9 @@ class Territory
 
     /**
      * Retrieve the child territories of a parent territory
-     * @param string $parentTerritoryCode
-     * @param bool $expandSubGroups=false Set to true to expand the sub-groups, false to retrieve them.
-     * @return array Return the list of territory codes that are children of $parentTerritoryCode (if $parentTerritoryCode is invalid you'll get an empty list)
+     * @param  string $parentTerritoryCode
+     * @param  bool   $expandSubGroups=false Set to true to expand the sub-groups, false to retrieve them.
+     * @return array  Return the list of territory codes that are children of $parentTerritoryCode (if $parentTerritoryCode is invalid you'll get an empty list)
      */
     public static function getChildTerritoryCodes($parentTerritoryCode, $expandSubGroups = false)
     {

--- a/code/Unit.php
+++ b/code/Unit.php
@@ -8,10 +8,10 @@ class Unit
 {
     /**
      * Format a unit string
-     * @param int|float|string $number The unit amount
-     * @param string $unit The unit identifier (eg 'duration/millisecond' or 'millisecond')
-     * @param string $width='short' The format name; it can be 'long' (eg '3 milliseconds'), 'short' (eg '3 ms') or 'narrow' (eg '3ms'). You can also add a precision specifier ('long,2' or just '2')
-     * @param string $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
+     * @param  int|float|string         $number        The unit amount
+     * @param  string                   $unit          The unit identifier (eg 'duration/millisecond' or 'millisecond')
+     * @param  string                   $width='short' The format name; it can be 'long' (eg '3 milliseconds'), 'short' (eg '3 ms') or 'narrow' (eg '3ms'). You can also add a precision specifier ('long,2' or just '2')
+     * @param  string                   $locale=''     The locale to use. If empty we'll use the default locale set in \Punic\Data
      * @return string
      * @throws Exception\ValueNotInList
      */
@@ -92,8 +92,8 @@ class Unit
 
     /**
      * Retrieve the measurement systems and their localized names
-     * @param string $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
-     * @return array The array keys are the measurement system codes (eg 'metric', 'US', 'UK'), the values are the localized measurement system names (eg 'Metric', 'US', 'UK' for English)
+     * @param  string $locale='' The locale to use. If empty we'll use the default locale set in \Punic\Data
+     * @return array  The array keys are the measurement system codes (eg 'metric', 'US', 'UK'), the values are the localized measurement system names (eg 'Metric', 'US', 'UK' for English)
      */
     public static function getMeasurementSystems($locale = '')
     {
@@ -102,7 +102,7 @@ class Unit
 
     /**
      * Retrieve the measurement system for a specific territory
-     * @param string $territoryCode The territory code (eg. 'US' for 'United States of America').
+     * @param  string $territoryCode The territory code (eg. 'US' for 'United States of America').
      * @return string Return the measurement system code (eg: 'metric') for the specified territory. If $territoryCode is not valid we'll return an empty string.
      */
     public static function getMeasurementSystemFor($territoryCode)
@@ -125,8 +125,8 @@ class Unit
 
     /**
      * Returns the list of countries that use a specific measurement system
-     * @param string $measurementSystem The measurement system identifier ('metric', 'US' or 'UK')
-     * @return array The list of country IDs that use the specified measurement system (if $measurementSystem is invalid you'll get an empty array)
+     * @param  string $measurementSystem The measurement system identifier ('metric', 'US' or 'UK')
+     * @return array  The list of country IDs that use the specified measurement system (if $measurementSystem is invalid you'll get an empty array)
      */
     public static function getCountriesWithMeasurementSystem($measurementSystem)
     {
@@ -166,7 +166,7 @@ class Unit
 
     /**
      * Retrieve the standard paper size for a specific territory
-     * @param string $territoryCode The territory code (eg. 'US' for 'United States of America').
+     * @param  string $territoryCode The territory code (eg. 'US' for 'United States of America').
      * @return string Return the standard paper size (eg: 'A4' or 'US-Letter') for the specified territory. If $territoryCode is not valid we'll return an empty string.
      */
     public static function getPaperSizeFor($territoryCode)
@@ -189,8 +189,8 @@ class Unit
 
     /**
      * Returns the list of countries that use a specific paper size by default
-     * @param string $paperSize The paper size identifier ('A4' or 'US-Letter')
-     * @return array The list of country IDs that use the specified paper size (if $paperSize is invalid you'll get an empty array)
+     * @param  string $paperSize The paper size identifier ('A4' or 'US-Letter')
+     * @return array  The list of country IDs that use the specified paper size (if $paperSize is invalid you'll get an empty array)
      */
     public static function getCountriesWithPaperSize($paperSize)
     {


### PR DESCRIPTION
@mlocati not quite sure about this, but when I run `php-cs-fixer` it changes most files to indent the variable name in the doc comments. Are you using a custom configuration? Would be cool if both of us had the same formatting options to have a consistent code layout.

In most cases it's easier to read but in some case we'd get a huge indentation..