### PR TITLE
Don't match backslash character

### DIFF
--- a/code/Data.php
+++ b/code/Data.php
@@ -119,7 +119,7 @@ class Data
             static::$cache[$locale] = array();
         }
         if (!isset(static::$cache[$locale][$identifier])) {
-            if (!@preg_match('/^[a-zA-Z0-1_\\-]+$/i', $identifier)) {
+            if (!preg_match('/^[a-z0-1_-]+$/i', $identifier)) {
                 throw new Exception\InvalidDataFile($identifier);
             }
             $dir = static::getLocaleFolder($locale);
@@ -165,7 +165,7 @@ class Data
         if (isset(static::$cacheGeneric[$identifier])) {
             return static::$cacheGeneric[$identifier];
         }
-        if (!preg_match('/^[a-zA-Z0-1_\\-]+$/', $identifier)) {
+        if (!preg_match('/^[a-zA-Z0-1_-]+$/', $identifier)) {
             throw new Exception\InvalidDataFile($identifier);
         }
         $file = 'data' . DIRECTORY_SEPARATOR . "$identifier.json";


### PR DESCRIPTION
\ is a valid path separator on Windows and it doesn't seem to make much sense in my opinion to match it here as well. Furthermore the `/i` flag will already match case-insensitive thus the `A-Z` can be removed as well here.