### PR TITLE
test natural sorting

### DIFF
--- a/code/Comparer.php
+++ b/code/Comparer.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace Punic;
+
+/**
+ * Various helper stuff.
+ */
+class Comparer
+{
+    /**
+     * @var array
+     */
+    private $cache;
+
+    /**
+     * @var bool
+     */
+    private $caseSensitive;
+
+    /**
+     * @var \Collator|null
+     */
+    private $collator;
+
+    /**
+     * @var bool
+     */
+    private $iconv;
+
+    /**
+     * Initializes the instance.
+     *
+     * @param string $locale
+     * @param bool $caseSensitive
+     */
+    public function __construct($locale = null, $caseSensitive = false)
+    {
+        $this->cache = array();
+        $this->locale = isset($locale) ? $locale : \Punic\Data::getDefaultLocale();
+        $this->caseSensitive = (bool) $caseSensitive;
+        $this->collator = class_exists('\Collator') ? new \Collator($this->locale) : null;
+        $this->iconv = function_exists('iconv');
+    }
+
+    /**
+     * @param string $str
+     *
+     * @return string
+     */
+    private function normalize($str)
+    {
+        $str = (string) $str;
+        if (!isset($this->cache[$str])) {
+            $this->cache[$str] = $str;
+            if ($str !== '') {
+                if ($this->iconv) {
+                    $transliterated = @iconv('UTF-8', 'ASCII//IGNORE//TRANSLIT', $str);
+                    if ($transliterated !== false) {
+                        $this->cache[$str] = $transliterated;
+                    }
+                }
+            }
+        }
+
+        return $this->cache[$str];
+    }
+
+    /**
+     * Compare two strings.
+     *
+     * @param string $a
+     * @param string $b
+     *
+     * @return int
+     */
+    public function compare($a, $b)
+    {
+        if (isset($this->collator)) {
+            $a = (string) $a;
+            $b = (string) $b;
+            if ($this->caseSensitive) {
+                $result = $this->collator->compare($a, $b);
+            } else {
+                $array = array($a, $b);
+                if ($this->sort($array) === false) {
+                    $result = false;
+                } else {
+                    $ia = array_search($a, $array);
+                    if ($ia === 1) {
+                        $result = 1;
+                    } else {
+                        $ib = array_search($b, $array);
+                        if ($ib === 1) {
+                            $result = -1;
+                        } else {
+                            $result = 0;
+                        }
+                    }
+                }
+            }
+        } else {
+            $a = $this->normalize($a);
+            $b = $this->normalize($b);
+
+            $result = $this->caseSensitive ? strnatcmp($a, $b) : strnatcasecmp($a, $b);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param array $array
+     * @param bool $keepKeys
+     *
+     * @return array
+     */
+    public function sort(&$array, $keepKeys = false)
+    {
+        $me = $this;
+        if ($keepKeys) {
+            if (isset($this->collator)) {
+                $result = $this->collator->asort($array);
+            } else {
+                $result = uasort(
+                    $array,
+                    function ($a, $b) use ($me) {
+                        return $me->compare($a, $b);
+                    }
+                );
+            }
+        } else {
+            if (isset($this->collator)) {
+                $result = $this->collator->sort($array);
+            } else {
+                $result = usort(
+                    $array,
+                    function ($a, $b) use ($me) {
+                        return $me->compare($a, $b);
+                    }
+                );
+            }
+        }
+
+        return $result;
+    }
+}

--- a/code/Currency.php
+++ b/code/Currency.php
@@ -43,7 +43,8 @@ class Currency
                 $result = array_intersect_key($result, $tenderCurrencies);
             }
         }
-        natcasesort($result);
+        $sorter = new \Punic\Comparer();
+        $sorter->sort($result, true);
 
         return $result;
     }

--- a/code/Language.php
+++ b/code/Language.php
@@ -40,7 +40,8 @@ class Language
         foreach (array_filter(array_keys($data), $filter) as $languageID) {
             $result[$languageID] = $data[$languageID];
         }
-        natcasesort($result);
+        $sorter = new \Punic\Comparer();
+        $sorter->sort($result, true);
 
         return $result;
     }

--- a/code/Territory.php
+++ b/code/Territory.php
@@ -133,7 +133,8 @@ class Territory
         $finalized = self::finalizeWithNames(Data::get('territories', $locale), $struct, $flatList);
 
         if ($flatList) {
-            natcasesort($finalized);
+            $sorter = new \Punic\Comparer();
+            $sorter->sort($finalized, true);
         } else {
             $finalized = static::sort($finalized);
         }
@@ -437,8 +438,9 @@ class Territory
                 $list[$i]['children'] = static::sort($list[$i]['children']);
             }
         }
-        uasort($list, function ($a, $b) {
-            return strcasecmp($a['name'], $b['name']);
+        $sorter = new \Punic\Comparer();
+        uasort($list, function ($a, $b) use($sorter) {
+            return $sorter->compare($a['name'], $b['name']);
         });
 
         return $list;

--- a/punic.php
+++ b/punic.php
@@ -1,22 +1,13 @@
 <?php
 
-require_once __DIR__.'/code/Calendar.php';
-require_once __DIR__.'/code/Currency.php';
-require_once __DIR__.'/code/Data.php';
-require_once __DIR__.'/code/Exception.php';
-require_once __DIR__.'/code/Exception/BadArgumentType.php';
-require_once __DIR__.'/code/Exception/BadDataFileContents.php';
-require_once __DIR__.'/code/Exception/DataFileNotFound.php';
-require_once __DIR__.'/code/Exception/DataFileNotReadable.php';
-require_once __DIR__.'/code/Exception/DataFolderNotFound.php';
-require_once __DIR__.'/code/Exception/InvalidDataFile.php';
-require_once __DIR__.'/code/Exception/InvalidLocale.php';
-require_once __DIR__.'/code/Exception/NotImplemented.php';
-require_once __DIR__.'/code/Exception/ValueNotInList.php';
-require_once __DIR__.'/code/Language.php';
-require_once __DIR__.'/code/Misc.php';
-require_once __DIR__.'/code/Number.php';
-require_once __DIR__.'/code/Phone.php';
-require_once __DIR__.'/code/Plural.php';
-require_once __DIR__.'/code/Territory.php';
-require_once __DIR__.'/code/Unit.php';
+spl_autoload_register(
+    function ($class) {
+        if (strpos($class, 'Punic\\') !== 0) {
+            return;
+        }
+        $file = __DIR__.DIRECTORY_SEPARATOR.'code'.str_replace('\\', DIRECTORY_SEPARATOR, substr($class, strlen('Punic'))).'.php';
+        if (is_file($file)) {
+            require_once $file;
+        }
+    }
+);

--- a/tests/Territory/TerritoryTest.php
+++ b/tests/Territory/TerritoryTest.php
@@ -201,6 +201,6 @@ class TerritoryTest extends PHPUnit_Framework_TestCase
         $indexCyprus = array_search(array_search('Zypern', $countries), $countryKeys);
         $indexAustria = array_search(array_search('Österreich', $countries), $countryKeys);
 
-        $this->assertGreaterThan($indexAustria, $indexCyprus, 'Österreich was not listed before Zypren');
+        $this->assertGreaterThan($indexAustria, $indexCyprus, 'Österreich was not listed before Zypern');
     }
 }

--- a/tests/Territory/TerritoryTest.php
+++ b/tests/Territory/TerritoryTest.php
@@ -193,4 +193,14 @@ class TerritoryTest extends PHPUnit_Framework_TestCase
             $this->assertNotContains($childTerritoryCode, $children);
         }
     }
+
+    public function testSorting()
+    {
+        $countries = Territory::getCountries('de_DE');
+        $countryKeys = array_keys($countries);
+        $indexCyprus = array_search(array_search('Zypern', $countries), $countryKeys);
+        $indexAustria = array_search(array_search('Österreich', $countries), $countryKeys);
+
+        $this->assertGreaterThan($indexAustria, $indexCyprus, 'Österreich was not listed before Zypren');
+    }
 }


### PR DESCRIPTION
It seems like we shoulnd't use `natcasesort` as it won't sort `Österreich` and `Zypren` properly.
The `Ö` character should be considered as `O`, but it doesn't seem to happen.

Same happened to Drupal:
https://www.drupal.org/node/1380432

We could use `strcoll` for *nix based systems, but that won't work on Windows, more about this here: http://stackoverflow.com/questions/832709/natural-sorting-algorithm-in-php-with-support-for-unicode

@mlocati any idea on how to approach this?