### PR TITLE
replace is_null with null ==

### DIFF
--- a/code/Calendar.php
+++ b/code/Calendar.php
@@ -72,24 +72,24 @@ class Calendar
             if (is_int($value) || is_float($value)) {
                 $result = new \DateTime();
                 $result->setTimestamp($value);
-                if (!is_null($tzFrom)) {
+                if (null !=($tzFrom)) {
                     $result->setTimezone($tzFrom);
                 }
             } elseif ($value instanceof \DateTime) {
                 $result = clone $value;
-                if (!is_null($tzFrom)) {
+                if (null !=($tzFrom)) {
                     $result->setTimezone($tzFrom);
                 }
             } elseif (is_string($value)) {
                 if (is_numeric($value)) {
                     $result = new \DateTime();
                     $result->setTimestamp($value);
-                    if (!is_null($tzFrom)) {
+                    if (null !=($tzFrom)) {
                         $result->setTimezone($tzFrom);
                     }
                 } else {
                     try {
-                        if (is_null($tzFrom)) {
+                        if (null ==($tzFrom)) {
                             $result = new \DateTime($value);
                         } else {
                             $result = new \DateTime($value, $tzFrom);
@@ -259,7 +259,7 @@ class Calendar
             } elseif (is_a($value, '\DateTime')) {
                 $year = intval($value->format('Y'));
             }
-            if (is_null($year)) {
+            if (null ==($year)) {
                 throw new Exception\BadArgumentType($value, 'year number');
             }
             $data = Data::get('calendar', $locale);
@@ -303,7 +303,7 @@ class Calendar
             } elseif (is_a($value, '\DateTime')) {
                 $month = intval($value->format('n'));
             }
-            if (is_null($month) || (($month < 1) || ($month > 12))) {
+            if (null ==($month) || (($month < 1) || ($month > 12))) {
                 throw new Exception\BadArgumentType($value, 'month number');
             }
             $data = Data::get('calendar', $locale);
@@ -347,7 +347,7 @@ class Calendar
             } elseif (is_a($value, '\DateTime')) {
                 $weekday = intval($value->format('w'));
             }
-            if (is_null($weekday) || (($weekday < 0) || ($weekday > 6))) {
+            if (null ==($weekday) || (($weekday < 0) || ($weekday > 6))) {
                 throw new Exception\BadArgumentType($value, 'weekday number');
             }
             $weekday = self::$weekdayDictionary[$weekday];
@@ -392,7 +392,7 @@ class Calendar
             } elseif (is_a($value, '\DateTime')) {
                 $quarter = 1 + intval(floor((intval($value->format('n')) - 1) / 3));
             }
-            if (is_null($quarter) || (($quarter < 1) || ($quarter > 4))) {
+            if (null ==($quarter) || (($quarter < 1) || ($quarter > 4))) {
                 throw new Exception\BadArgumentType($value, 'quarter number');
             }
             $data = Data::get('calendar', $locale);
@@ -443,10 +443,10 @@ class Calendar
             } elseif (is_a($value, '\DateTime')) {
                 $dayperiod = $value->format('a');
             }
-            if ((!is_null($hours)) && ($hours >= 0) && ($hours <= 23)) {
+            if ((null !=($hours)) && ($hours >= 0) && ($hours <= 23)) {
                 $dayperiod = ($hours < 12) ? 'am' : 'pm';
             }
-            if (is_null($dayperiod)) {
+            if (null ==($dayperiod)) {
                 throw new Exception\BadArgumentType($value, 'day period');
             }
             $data = Data::get('calendar', $locale);

--- a/code/Calendar.php
+++ b/code/Calendar.php
@@ -72,24 +72,24 @@ class Calendar
             if (is_int($value) || is_float($value)) {
                 $result = new \DateTime();
                 $result->setTimestamp($value);
-                if (null !=($tzFrom)) {
+                if (!is_null($tzFrom)) {
                     $result->setTimezone($tzFrom);
                 }
             } elseif ($value instanceof \DateTime) {
                 $result = clone $value;
-                if (null !=($tzFrom)) {
+                if (!is_null($tzFrom)) {
                     $result->setTimezone($tzFrom);
                 }
             } elseif (is_string($value)) {
                 if (is_numeric($value)) {
                     $result = new \DateTime();
                     $result->setTimestamp($value);
-                    if (null !=($tzFrom)) {
+                    if (!is_null($tzFrom)) {
                         $result->setTimezone($tzFrom);
                     }
                 } else {
                     try {
-                        if (null ==($tzFrom)) {
+                        if (is_null($tzFrom)) {
                             $result = new \DateTime($value);
                         } else {
                             $result = new \DateTime($value, $tzFrom);
@@ -259,7 +259,7 @@ class Calendar
             } elseif (is_a($value, '\DateTime')) {
                 $year = intval($value->format('Y'));
             }
-            if (null ==($year)) {
+            if (is_null($year)) {
                 throw new Exception\BadArgumentType($value, 'year number');
             }
             $data = Data::get('calendar', $locale);
@@ -303,7 +303,7 @@ class Calendar
             } elseif (is_a($value, '\DateTime')) {
                 $month = intval($value->format('n'));
             }
-            if (null ==($month) || (($month < 1) || ($month > 12))) {
+            if (is_null($month) || (($month < 1) || ($month > 12))) {
                 throw new Exception\BadArgumentType($value, 'month number');
             }
             $data = Data::get('calendar', $locale);
@@ -347,7 +347,7 @@ class Calendar
             } elseif (is_a($value, '\DateTime')) {
                 $weekday = intval($value->format('w'));
             }
-            if (null ==($weekday) || (($weekday < 0) || ($weekday > 6))) {
+            if (is_null($weekday) || (($weekday < 0) || ($weekday > 6))) {
                 throw new Exception\BadArgumentType($value, 'weekday number');
             }
             $weekday = self::$weekdayDictionary[$weekday];
@@ -392,7 +392,7 @@ class Calendar
             } elseif (is_a($value, '\DateTime')) {
                 $quarter = 1 + intval(floor((intval($value->format('n')) - 1) / 3));
             }
-            if (null ==($quarter) || (($quarter < 1) || ($quarter > 4))) {
+            if (is_null($quarter) || (($quarter < 1) || ($quarter > 4))) {
                 throw new Exception\BadArgumentType($value, 'quarter number');
             }
             $data = Data::get('calendar', $locale);
@@ -443,10 +443,10 @@ class Calendar
             } elseif (is_a($value, '\DateTime')) {
                 $dayperiod = $value->format('a');
             }
-            if ((null !=($hours)) && ($hours >= 0) && ($hours <= 23)) {
+            if ((!is_null($hours)) && ($hours >= 0) && ($hours <= 23)) {
                 $dayperiod = ($hours < 12) ? 'am' : 'pm';
             }
-            if (null ==($dayperiod)) {
+            if (is_null($dayperiod)) {
                 throw new Exception\BadArgumentType($value, 'day period');
             }
             $data = Data::get('calendar', $locale);

--- a/code/Calendar.php
+++ b/code/Calendar.php
@@ -72,24 +72,24 @@ class Calendar
             if (is_int($value) || is_float($value)) {
                 $result = new \DateTime();
                 $result->setTimestamp($value);
-                if (!is_null($tzFrom)) {
+                if (null !== ($tzFrom)) {
                     $result->setTimezone($tzFrom);
                 }
             } elseif ($value instanceof \DateTime) {
                 $result = clone $value;
-                if (!is_null($tzFrom)) {
+                if (null !== ($tzFrom)) {
                     $result->setTimezone($tzFrom);
                 }
             } elseif (is_string($value)) {
                 if (is_numeric($value)) {
                     $result = new \DateTime();
                     $result->setTimestamp($value);
-                    if (!is_null($tzFrom)) {
+                    if (null !== ($tzFrom)) {
                         $result->setTimezone($tzFrom);
                     }
                 } else {
                     try {
-                        if (is_null($tzFrom)) {
+                        if (null === ($tzFrom)) {
                             $result = new \DateTime($value);
                         } else {
                             $result = new \DateTime($value, $tzFrom);
@@ -259,7 +259,7 @@ class Calendar
             } elseif (is_a($value, '\DateTime')) {
                 $year = intval($value->format('Y'));
             }
-            if (is_null($year)) {
+            if (null === ($year)) {
                 throw new Exception\BadArgumentType($value, 'year number');
             }
             $data = Data::get('calendar', $locale);
@@ -303,7 +303,7 @@ class Calendar
             } elseif (is_a($value, '\DateTime')) {
                 $month = intval($value->format('n'));
             }
-            if (is_null($month) || (($month < 1) || ($month > 12))) {
+            if (null === ($month) || (($month < 1) || ($month > 12))) {
                 throw new Exception\BadArgumentType($value, 'month number');
             }
             $data = Data::get('calendar', $locale);
@@ -347,7 +347,7 @@ class Calendar
             } elseif (is_a($value, '\DateTime')) {
                 $weekday = intval($value->format('w'));
             }
-            if (is_null($weekday) || (($weekday < 0) || ($weekday > 6))) {
+            if (null === ($weekday) || (($weekday < 0) || ($weekday > 6))) {
                 throw new Exception\BadArgumentType($value, 'weekday number');
             }
             $weekday = self::$weekdayDictionary[$weekday];
@@ -392,7 +392,7 @@ class Calendar
             } elseif (is_a($value, '\DateTime')) {
                 $quarter = 1 + intval(floor((intval($value->format('n')) - 1) / 3));
             }
-            if (is_null($quarter) || (($quarter < 1) || ($quarter > 4))) {
+            if (null === ($quarter) || (($quarter < 1) || ($quarter > 4))) {
                 throw new Exception\BadArgumentType($value, 'quarter number');
             }
             $data = Data::get('calendar', $locale);
@@ -443,10 +443,10 @@ class Calendar
             } elseif (is_a($value, '\DateTime')) {
                 $dayperiod = $value->format('a');
             }
-            if ((!is_null($hours)) && ($hours >= 0) && ($hours <= 23)) {
+            if ((null !== ($hours)) && ($hours >= 0) && ($hours <= 23)) {
                 $dayperiod = ($hours < 12) ? 'am' : 'pm';
             }
-            if (is_null($dayperiod)) {
+            if (null === ($dayperiod)) {
                 throw new Exception\BadArgumentType($value, 'day period');
             }
             $data = Data::get('calendar', $locale);

--- a/code/Currency.php
+++ b/code/Currency.php
@@ -68,7 +68,7 @@ class Currency
         $data = static::getLocaleData($currencyCode, $locale);
         if (is_array($data)) {
             $result = $data['name'];
-            if ((!is_null($quantity)) && isset($data['pluralName'])) {
+            if ((null !=($quantity)) && isset($data['pluralName'])) {
                 if (is_string($data) && in_array($quantity, array('zero', 'one', 'two', 'few', 'many', 'other'))) {
                     $pluralRule = $quantity;
                 } else {

--- a/code/Currency.php
+++ b/code/Currency.php
@@ -68,7 +68,7 @@ class Currency
         $data = static::getLocaleData($currencyCode, $locale);
         if (is_array($data)) {
             $result = $data['name'];
-            if ((!is_null($quantity)) && isset($data['pluralName'])) {
+            if ((null !== ($quantity)) && isset($data['pluralName'])) {
                 if (is_string($data) && in_array($quantity, array('zero', 'one', 'two', 'few', 'many', 'other'))) {
                     $pluralRule = $quantity;
                 } else {

--- a/code/Currency.php
+++ b/code/Currency.php
@@ -68,7 +68,7 @@ class Currency
         $data = static::getLocaleData($currencyCode, $locale);
         if (is_array($data)) {
             $result = $data['name'];
-            if ((null !=($quantity)) && isset($data['pluralName'])) {
+            if ((!is_null($quantity)) && isset($data['pluralName'])) {
                 if (is_string($data) && in_array($quantity, array('zero', 'one', 'two', 'few', 'many', 'other'))) {
                     $pluralRule = $quantity;
                 } else {

--- a/code/Data.php
+++ b/code/Data.php
@@ -66,7 +66,7 @@ class Data
      */
     public static function setDefaultLocale($locale)
     {
-        if (is_null(static::explodeLocale($locale))) {
+        if (null === (static::explodeLocale($locale))) {
             throw new Exception\InvalidLocale($locale);
         }
         static::$defaultLocale = $locale;
@@ -103,7 +103,7 @@ class Data
      */
     public static function setFallbackLocale($locale)
     {
-        if (is_null(static::explodeLocale($locale))) {
+        if (null === (static::explodeLocale($locale))) {
             throw new Exception\InvalidLocale($locale);
         }
         if (static::$fallbackLocale !== $locale) {
@@ -281,7 +281,7 @@ class Data
                 $result = $data[$key];
                 if (isset($script[0]) && (stripos($result, "$language-$script-") !== 0)) {
                     $parts = static::explodeLocale($result);
-                    if (!is_null($parts)) {
+                    if (null !== ($parts)) {
                         $result = "{$parts['language']}-$script-{$parts['territory']}";
                     }
                 }

--- a/code/Data.php
+++ b/code/Data.php
@@ -66,7 +66,7 @@ class Data
      */
     public static function setDefaultLocale($locale)
     {
-        if (is_null(static::explodeLocale($locale))) {
+        if (null ==(static::explodeLocale($locale))) {
             throw new Exception\InvalidLocale($locale);
         }
         static::$defaultLocale = $locale;
@@ -103,7 +103,7 @@ class Data
      */
     public static function setFallbackLocale($locale)
     {
-        if (is_null(static::explodeLocale($locale))) {
+        if (null ==(static::explodeLocale($locale))) {
             throw new Exception\InvalidLocale($locale);
         }
         if (static::$fallbackLocale !== $locale) {
@@ -281,7 +281,7 @@ class Data
                 $result = $data[$key];
                 if (isset($script[0]) && (stripos($result, "$language-$script-") !== 0)) {
                     $parts = static::explodeLocale($result);
-                    if (!is_null($parts)) {
+                    if (null !=($parts)) {
                         $result = "{$parts['language']}-$script-{$parts['territory']}";
                     }
                 }

--- a/code/Data.php
+++ b/code/Data.php
@@ -66,7 +66,7 @@ class Data
      */
     public static function setDefaultLocale($locale)
     {
-        if (null ==(static::explodeLocale($locale))) {
+        if (is_null(static::explodeLocale($locale))) {
             throw new Exception\InvalidLocale($locale);
         }
         static::$defaultLocale = $locale;
@@ -103,7 +103,7 @@ class Data
      */
     public static function setFallbackLocale($locale)
     {
-        if (null ==(static::explodeLocale($locale))) {
+        if (is_null(static::explodeLocale($locale))) {
             throw new Exception\InvalidLocale($locale);
         }
         if (static::$fallbackLocale !== $locale) {
@@ -281,7 +281,7 @@ class Data
                 $result = $data[$key];
                 if (isset($script[0]) && (stripos($result, "$language-$script-") !== 0)) {
                     $parts = static::explodeLocale($result);
-                    if (null !=($parts)) {
+                    if (!is_null($parts)) {
                         $result = "{$parts['language']}-$script-{$parts['territory']}";
                     }
                 }

--- a/code/Language.php
+++ b/code/Language.php
@@ -57,7 +57,7 @@ class Language
     {
         $result = $languageCode;
         $info = Data::explodeLocale($languageCode);
-        if (null !=($info)) {
+        if (!is_null($info)) {
             $language = $info['language'];
             $script = $info['script'];
             $territory = $info['territory'];

--- a/code/Language.php
+++ b/code/Language.php
@@ -57,7 +57,7 @@ class Language
     {
         $result = $languageCode;
         $info = Data::explodeLocale($languageCode);
-        if (!is_null($info)) {
+        if (null !=($info)) {
             $language = $info['language'];
             $script = $info['script'];
             $territory = $info['territory'];

--- a/code/Language.php
+++ b/code/Language.php
@@ -57,7 +57,7 @@ class Language
     {
         $result = $languageCode;
         $info = Data::explodeLocale($languageCode);
-        if (!is_null($info)) {
+        if (null !== ($info)) {
             $language = $info['language'];
             $script = $info['script'];
             $territory = $info['territory'];

--- a/code/Misc.php
+++ b/code/Misc.php
@@ -72,7 +72,7 @@ class Misc
                             }
                         }
                     }
-                    if (is_null($data)) {
+                    if (null ==($data)) {
                         $data = $allData['standard'];
                     }
                     if (isset($data[$n])) {

--- a/code/Misc.php
+++ b/code/Misc.php
@@ -72,7 +72,7 @@ class Misc
                             }
                         }
                     }
-                    if (null ==($data)) {
+                    if (is_null($data)) {
                         $data = $allData['standard'];
                     }
                     if (isset($data[$n])) {

--- a/code/Misc.php
+++ b/code/Misc.php
@@ -72,7 +72,7 @@ class Misc
                             }
                         }
                     }
-                    if (is_null($data)) {
+                    if (null === ($data)) {
                         $data = $allData['standard'];
                     }
                     if (isset($data[$n])) {

--- a/code/Number.php
+++ b/code/Number.php
@@ -17,7 +17,7 @@ class Number
      */
     public static function isNumeric($value, $locale = '')
     {
-        return is_null(static::unformat($value, $locale)) ? false : true;
+        return null === (static::unformat($value, $locale)) ? false : true;
     }
 
     /**
@@ -76,9 +76,9 @@ class Number
                 }
             }
         }
-        if (!is_null($number)) {
+        if (null !== ($number)) {
             $precision = is_numeric($precision) ? intval($precision) : null;
-            if (!is_null($precision)) {
+            if (null !== ($precision)) {
                 $value = round($value, $precision);
             }
             $data = Data::get('numbers', $locale);
@@ -101,7 +101,7 @@ class Number
                 $intPart = $pre . $groupSign . implode($groupSign, str_split(substr($intPart, $preLength), $groupLength));
             }
             $result = $sign . $intPart;
-            if (is_null($precision)) {
+            if (null === ($precision)) {
                 if (isset($floatPath[0])) {
                     $result .= $decimal . $floatPath;
                 }
@@ -164,7 +164,7 @@ class Number
                     $sign = '';
                 }
                 $int = str_replace($group, '', $int);
-                if (is_null($float)) {
+                if (null === ($float)) {
                     $result = intval("$sign$int");
                 } else {
                     $result = floatval("$sign$int.$float");

--- a/code/Number.php
+++ b/code/Number.php
@@ -17,7 +17,7 @@ class Number
      */
     public static function isNumeric($value, $locale = '')
     {
-        return is_null(static::unformat($value, $locale)) ? false : true;
+        return null ==(static::unformat($value, $locale)) ? false : true;
     }
 
     /**
@@ -76,9 +76,9 @@ class Number
                 }
             }
         }
-        if (!is_null($number)) {
+        if (null !=($number)) {
             $precision = is_numeric($precision) ? intval($precision) : null;
-            if (!is_null($precision)) {
+            if (null !=($precision)) {
                 $value = round($value, $precision);
             }
             $data = Data::get('numbers', $locale);
@@ -101,7 +101,7 @@ class Number
                 $intPart = $pre . $groupSign . implode($groupSign, str_split(substr($intPart, $preLength), $groupLength));
             }
             $result = $sign . $intPart;
-            if (is_null($precision)) {
+            if (null ==($precision)) {
                 if (isset($floatPath[0])) {
                     $result .= $decimal . $floatPath;
                 }
@@ -164,7 +164,7 @@ class Number
                     $sign = '';
                 }
                 $int = str_replace($group, '', $int);
-                if (is_null($float)) {
+                if (null ==($float)) {
                     $result = intval("$sign$int");
                 } else {
                     $result = floatval("$sign$int.$float");

--- a/code/Number.php
+++ b/code/Number.php
@@ -17,7 +17,7 @@ class Number
      */
     public static function isNumeric($value, $locale = '')
     {
-        return null ==(static::unformat($value, $locale)) ? false : true;
+        return is_null(static::unformat($value, $locale)) ? false : true;
     }
 
     /**
@@ -76,9 +76,9 @@ class Number
                 }
             }
         }
-        if (null !=($number)) {
+        if (!is_null($number)) {
             $precision = is_numeric($precision) ? intval($precision) : null;
-            if (null !=($precision)) {
+            if (!is_null($precision)) {
                 $value = round($value, $precision);
             }
             $data = Data::get('numbers', $locale);
@@ -101,7 +101,7 @@ class Number
                 $intPart = $pre . $groupSign . implode($groupSign, str_split(substr($intPart, $preLength), $groupLength));
             }
             $result = $sign . $intPart;
-            if (null ==($precision)) {
+            if (is_null($precision)) {
                 if (isset($floatPath[0])) {
                     $result .= $decimal . $floatPath;
                 }
@@ -164,7 +164,7 @@ class Number
                     $sign = '';
                 }
                 $int = str_replace($group, '', $int);
-                if (null ==($float)) {
+                if (is_null($float)) {
                     $result = intval("$sign$int");
                 } else {
                     $result = floatval("$sign$int.$float");

--- a/code/Territory.php
+++ b/code/Territory.php
@@ -365,7 +365,7 @@ class Territory
     protected static function getStructure()
     {
         static $cache = null;
-        if (null ==($cache)) {
+        if (is_null($cache)) {
             $data = Data::getGeneric('territoryContainment');
             $result = static::fillStructure($data, '001', 0);
             $cache = $result;

--- a/code/Territory.php
+++ b/code/Territory.php
@@ -365,7 +365,7 @@ class Territory
     protected static function getStructure()
     {
         static $cache = null;
-        if (is_null($cache)) {
+        if (null ==($cache)) {
             $data = Data::getGeneric('territoryContainment');
             $result = static::fillStructure($data, '001', 0);
             $cache = $result;

--- a/code/Territory.php
+++ b/code/Territory.php
@@ -365,7 +365,7 @@ class Territory
     protected static function getStructure()
     {
         static $cache = null;
-        if (is_null($cache)) {
+        if (null === ($cache)) {
             $data = Data::getGeneric('territoryContainment');
             $result = static::fillStructure($data, '001', 0);
             $cache = $result;

--- a/code/Unit.php
+++ b/code/Unit.php
@@ -49,7 +49,7 @@ class Unit
             foreach (array_keys($data) as $c) {
                 if (strpos($c, '_') === false) {
                     if (isset($data[$c][$unit])) {
-                        if (is_null($unitCategory)) {
+                        if (null === ($unitCategory)) {
                             $unitCategory = $c;
                             $unitID = $unit;
                         } else {
@@ -63,10 +63,10 @@ class Unit
             list($unitCategory, $unitID) = explode('/', $unit, 2);
         }
         $rules = null;
-        if ((strpos($unit, '_') === false) && (!is_null($unitCategory)) && (!is_null($unitID)) && isset($data[$unitCategory]) && array_key_exists($unitID, $data[$unitCategory])) {
+        if ((strpos($unit, '_') === false) && (null !== ($unitCategory)) && (null !== ($unitID)) && isset($data[$unitCategory]) && array_key_exists($unitID, $data[$unitCategory])) {
             $rules = $data[$unitCategory][$unitID];
         }
-        if (is_null($rules)) {
+        if (null === ($rules)) {
             $units = array();
             foreach ($data as $c => $us) {
                 if (strpos($c, '_') === false) {

--- a/code/Unit.php
+++ b/code/Unit.php
@@ -49,7 +49,7 @@ class Unit
             foreach (array_keys($data) as $c) {
                 if (strpos($c, '_') === false) {
                     if (isset($data[$c][$unit])) {
-                        if (is_null($unitCategory)) {
+                        if (null ==($unitCategory)) {
                             $unitCategory = $c;
                             $unitID = $unit;
                         } else {
@@ -63,10 +63,10 @@ class Unit
             list($unitCategory, $unitID) = explode('/', $unit, 2);
         }
         $rules = null;
-        if ((strpos($unit, '_') === false) && (!is_null($unitCategory)) && (!is_null($unitID)) && isset($data[$unitCategory]) && array_key_exists($unitID, $data[$unitCategory])) {
+        if ((strpos($unit, '_') === false) && (null !=($unitCategory)) && (null !=($unitID)) && isset($data[$unitCategory]) && array_key_exists($unitID, $data[$unitCategory])) {
             $rules = $data[$unitCategory][$unitID];
         }
-        if (is_null($rules)) {
+        if (null ==($rules)) {
             $units = array();
             foreach ($data as $c => $us) {
                 if (strpos($c, '_') === false) {

--- a/code/Unit.php
+++ b/code/Unit.php
@@ -49,7 +49,7 @@ class Unit
             foreach (array_keys($data) as $c) {
                 if (strpos($c, '_') === false) {
                     if (isset($data[$c][$unit])) {
-                        if (null ==($unitCategory)) {
+                        if (is_null($unitCategory)) {
                             $unitCategory = $c;
                             $unitID = $unit;
                         } else {
@@ -63,10 +63,10 @@ class Unit
             list($unitCategory, $unitID) = explode('/', $unit, 2);
         }
         $rules = null;
-        if ((strpos($unit, '_') === false) && (null !=($unitCategory)) && (null !=($unitID)) && isset($data[$unitCategory]) && array_key_exists($unitID, $data[$unitCategory])) {
+        if ((strpos($unit, '_') === false) && (!is_null($unitCategory)) && (!is_null($unitID)) && isset($data[$unitCategory]) && array_key_exists($unitID, $data[$unitCategory])) {
             $rules = $data[$unitCategory][$unitID];
         }
-        if (null ==($rules)) {
+        if (is_null($rules)) {
             $units = array();
             foreach ($data as $c => $us) {
                 if (strpos($c, '_') === false) {


### PR DESCRIPTION
it's not something I want to merge, but I've noticed that `.. == null` is faster than `is_null`. Makes sense since it's just an operator and not a function call..

4 unit tests are failing though.. I also tried with `===` but that caused even more unit tests to fail.

The script mentioned here https://github.com/punic/punic/issues/32#issuecomment-70403783 is executed in about 8.4 seconds before and 7.3 seconds after this merge. Might be because of an error, will check this later.

(I'll replace them with `$var == null` if I'll actually want to merge this)