### PR TITLE
Fix comparer not to set the Collator if the 'intl' extension is not loaded.

### DIFF
--- a/code/Comparer.php
+++ b/code/Comparer.php
@@ -38,8 +38,13 @@ class Comparer
         $this->cache = array();
         $this->locale = isset($locale) ? $locale : \Punic\Data::getDefaultLocale();
         $this->caseSensitive = (bool) $caseSensitive;
-        $this->collator = class_exists('\Collator') ? new \Collator($this->locale) : null;
         $this->iconv = function_exists('iconv');
+        
+        if (class_exists('\Collator') && extension_loaded('intl')) {
+            $this->collator = new \Collator($this->locale);
+        } else {
+            $this->collator = null;
+        }
     }
 
     /**


### PR DESCRIPTION
Changes check for the presence of the extension before initialising and setting the Collator.

Not the most graceful, maybe @Remo setter idea could somehow work this in better, but it works.