### PR TITLE
Allow specifying minimum population percentage for Territory::getTerritoriesForLanguage

### DIFF
--- a/code/Territory.php
+++ b/code/Territory.php
@@ -259,34 +259,31 @@ class Territory
      * Return a list of territory IDs where a specific language is spoken, sorted by the total number of people speaking that language.
      *
      * @param string $languageID The language identifier
+     * @param float $threshold The minimum percentage (from 0 to 100) to consider a language as spoken in a Country
      *
      * @return array
      */
-    public static function getTerritoriesForLanguage($languageID)
+    public static function getTerritoriesForLanguage($languageID, $threshold = 0)
     {
-        $langPeople = array();
+        $peopleInTerritory = array();
         foreach (Data::getGeneric('territoryInfo') as $territoryID => $territoryInfo) {
+            $percentage = null;
             foreach ($territoryInfo['languages'] as $langID => $langInfo) {
                 if ((strcasecmp($languageID, $langID) === 0) || (stripos($langID, $languageID.'_') === 0)) {
-                    $langPeople[] = array('territoryID' => $territoryID, 'people' => $territoryInfo['population'] * $langInfo['population']);
+                    if ($percentage === null) {
+                        $percentage = $langInfo['population'];
+                    } else {
+                        $percentage += $langInfo['population'];
+                    }
                 }
             }
+            if ($percentage !== null && $percentage >= $threshold) {
+                $peopleInTerritory[$territoryID] = $territoryInfo['population'] * $percentage;
+            }
         }
-        usort($langPeople, function ($a, $b) {
-               $delta = $a['people'] - $b['people'];
-               if ($delta != 0) {
-                   $result = ($delta > 0) ? -1 : 1;
-               } else {
-                   $result = strcmp($a['territoryID'], $b['territoryID']);
-               }
-
-               return $result;
-        });
-        $territoryIDs = array();
-        foreach ($langPeople as $lp) {
-            $territoryIDs[] = $lp['territoryID'];
-        }
-
+        arsort($peopleInTerritory, SORT_NUMERIC);
+        $territoryIDs = array_keys($peopleInTerritory);
+        
         return $territoryIDs;
     }
 

--- a/tests/Territory/TerritoryTest.php
+++ b/tests/Territory/TerritoryTest.php
@@ -142,9 +142,13 @@ class TerritoryTest extends PHPUnit_Framework_TestCase
     public function testTerritoriesForLanguage()
     {
         $this->assertEmpty(Territory::getTerritoriesForLanguage('fake'));
-        $us = Territory::getTerritoriesForLanguage('en');
-        $this->assertSame('US', $us[0]);
-        $this->assertContains('GB', $us);
+        $en = Territory::getTerritoriesForLanguage('en', 0);
+        $this->assertSame('US', $en[0]);
+        $this->assertContains('GB', $en);
+        $this->assertContains('IT', $en);
+        $enThreshold = Territory::getTerritoriesForLanguage('en', 80);
+        $this->assertSame('US', $enThreshold[0]);
+        $this->assertNotContains('IT', $enThreshold);
         $it = Territory::getTerritoriesForLanguage('it');
         $this->assertSame('IT', $it[0]);
         $this->assertContains('CH', $it);


### PR DESCRIPTION
For instance, the array returned by `Territory::getTerritoriesForLanguage('en', 30)` will include `'IT'`, but the array returned by `Territory::getTerritoriesForLanguage('en', 40)` won't include `'IT'` since English in Italy is spoken by 34% of population.