### PR TITLE
Avoid iconv warnings with old PHP versions

### DIFF
--- a/code/Comparer.php
+++ b/code/Comparer.php
@@ -63,7 +63,7 @@ class Comparer
             $this->cache[$str] = $str;
             if ($str !== '') {
                 if ($this->iconv) {
-                    $transliterated = @iconv('UTF-8', 'ASCII//IGNORE//TRANSLIT', $str);
+                    $transliterated = @iconv('UTF-8', 'ASCII//TRANSLIT', $str);
                     if ($transliterated !== false) {
                         $this->cache[$str] = $transliterated;
                     }


### PR DESCRIPTION
On old PHP versions (eg 5.5.9) without the intl extension, the Comparer function fails with the following error message:
Array was modified by the user comparison function

This is not the actual problem, PHP gives the wrong message.
The problem is due to the fact that old iconv functions raise this warning if the //IGNORE flag is set:
Detected an illegal character in input string

For some obscure reason, if that warning is raised, PHP tells that we modified the array we're sorting.

Let's remove that flag.

Example:
https://3v4l.org/XJOA8
vs
https://3v4l.org/Emqdo
