### PR TITLE
Handle double quote inside quoted text

### DIFF
--- a/code/Calendar.php
+++ b/code/Calendar.php
@@ -2232,13 +2232,11 @@ class Calendar
             for ($index = 0; $index < $length; ++$index) {
                 $char = $format[$index];
                 if ($char === "'") {
-                    if ($quoted) {
-                        $quoted = false;
-                    } elseif (($index < $lengthM1) && ($format[$index + 1] === "'")) {
+                    if (($index < $lengthM1) && ($format[$index + 1] === "'")) {
                         $result[] = "'";
                         ++$index;
                     } else {
-                        $quoted = true;
+                        $quoted = !$quoted;
                     }
                 } elseif ($quoted) {
                     $result[] = $char;

--- a/tests/Calendar/CalendarTest.php
+++ b/tests/Calendar/CalendarTest.php
@@ -1239,8 +1239,10 @@ class CalendarTest extends PHPUnit_Framework_TestCase
         $this->assertSame('+13:00', Calendar::format($dt, 'XXX'));
         $this->assertSame('+1300', Calendar::format($dt, 'XXXX'));
         $this->assertSame('+13:00', Calendar::format($dt, 'XXXXX'));
-        // Mixed
+        // Literal text
         $this->assertSame("2010'01", Calendar::format($dt, "yyyy''MM"));
+        $this->assertSame("2010''01", Calendar::format($dt, "yyyy''''MM"));
+        $this->assertSame("2010E'E01", Calendar::format($dt, "yyyy'E''E'MM"));
     }
 
     public function providerDescribeInterval()


### PR DESCRIPTION
`Calendar::format()` does not handle escaped single quotes inside single quotes.

The spec says:
> Two adjacent single vertical quotes (''), which represent a literal single quote, either inside or outside quoted text.

Example:
`Calendar::format($dt1, "y 'x''x' MMMM")`

Expected result:
`2016 x'x January`

Actual result:
`2016 xx January`