### PR TITLE
Implement getTimezoneNameLocationSpecific()

### DIFF
--- a/bin/build.php
+++ b/bin/build.php
@@ -1305,6 +1305,7 @@ class JSonConverter
             'likelySubtags.json' => NoopSupplementalPunicConversion::create(array('supplemental', 'likelySubtags')),
             'territoryContainment.json' => TerritoryContainmentSupplementalPunicConversion::create(),
             'metaZones.json' => MetaZonesSupplementalPunicConversion::create(),
+            'primaryZones.json' => NoopSupplementalPunicConversion::create(array('supplemental', 'primaryZones')),
             'plurals.json' => PluralsSupplementalPunicConversion::create(),
             'measurementData.json' => MeasurementDataSupplementalPunicConversion::create(),
             'currencyData.json' => CurrencyDataSupplementalPunicConversion::create(),

--- a/code/Calendar.php
+++ b/code/Calendar.php
@@ -913,7 +913,7 @@ class Calendar
                 }
             }
 
-            if (!isset($name[0])) {
+            if (!isset($name[0]) && substr($timezone->getName(), 0, 7) !== 'Etc/GMT') {
                 $name = static::getTimezoneExemplarCity($value, false, $locale);
             }
 

--- a/code/Calendar.php
+++ b/code/Calendar.php
@@ -2055,7 +2055,7 @@ class Calendar
             case 1:
                 return sprintf($format, $sign.$hours.(($minutes === 0) ? '' : (':'.substr('0'.$minutes, -2))));
             case 4:
-                return sprintf($format, $sign.$hours.':'.substr('0'.$minutes, -2));
+                return sprintf($format, $sign.substr('0'.$hours, -2).':'.substr('0'.$minutes, -2));
             default:
                 throw new Exception\ValueNotInList($count, array(1, 4));
         }

--- a/code/Calendar.php
+++ b/code/Calendar.php
@@ -859,10 +859,69 @@ class Calendar
         return $result;
     }
 
-    /** @todo I can't find data for this */
-    public static function getTimezoneNameLocationSpecific($value, $width = 'long', $kind = '', $locale = '')
+    /**
+     * Returns the localized name of a timezone, location-specific.
+     *
+     * @param string|\DateTime|\DateTimeZone $value the php name of a timezone, or a \DateTime instance or a \DateTimeZone instance for which you want the localized timezone name
+     * @param string $locale The locale to use. If empty we'll use the default locale set with {@link \Punic\Data::setDefaultLocale()}.
+     *
+     * @return string returns an empty string if the timezone has not been found, the timezone name otherwise
+     *
+     * @see http://www.unicode.org/reports/tr35/tr35-dates.html#Time_Zone_Goals
+     */
+    public static function getTimezoneNameLocationSpecific($value, $locale = '')
     {
-        return '';
+        $result = '';
+        if (!empty($value)) {
+            if (is_string($value)) {
+                $phpNames = static::getTimezonesAliases($value);
+                $timezone = null;
+                foreach ($phpNames as $phpName) {
+                    try {
+                        $timezone = new \DateTimeZone($phpName);
+                        break;
+                    } catch (\Exception $x) {
+                    }
+                }
+                if (!$timezone) {
+                    return '';
+                }
+            } elseif (is_a($value, '\\DateTime')) {
+                $timezone = $value->getTimezone();
+                if (empty($kind)) {
+                    if (intval($value->format('I')) === 1) {
+                        $kind = 'daylight';
+                    } else {
+                        $kind = 'standard';
+                    }
+                }
+            } elseif (is_a($value, '\\DateTimeZone')) {
+                $timezone = $value;
+            } else {
+                throw new Exception\BadArgumentType($value, 'string, DateTime, or DateTimeZone');
+            }
+
+            $name = '';
+            $location = $timezone->getLocation();
+            if (isset($location['country_code']) && $location['country_code'] !== '??') {
+                $data = Data::getGeneric('primaryZones');
+                if (isset($data[$location['country_code']]) ||
+                    count(\DateTimeZone::listIdentifiers(\DateTimeZone::PER_COUNTRY, $location['country_code'])) === 1) {
+                    $name = Territory::getName($location['country_code'], $locale);
+                }
+            }
+
+            if (!isset($name[0])) {
+                $name = static::getTimezoneExemplarCity($timezone, false, $locale);
+            }
+
+            if (isset($name[0])) {
+                $data = Data::get('timeZoneNames', $locale);
+                $result = sprintf($data['regionFormat'], $name);
+            }
+        }
+
+        return $result;
     }
 
     /**
@@ -2194,7 +2253,7 @@ class Calendar
                 $result = static::getTimezoneExemplarCity($value, true, $locale);
                 break;
             case 4:
-                $result = static::getTimezoneNameLocationSpecific($value, 'short', 'generic', $locale);
+                $result = static::getTimezoneNameLocationSpecific($value, $locale);
                 if (!isset($result[0])) {
                     $result = static::decodeTimezoneShortGMT($value, 4, $locale);
                 }

--- a/code/data/primaryZones.json
+++ b/code/data/primaryZones.json
@@ -1,0 +1,1 @@
+{"CL":"America/Santiago","CN":"Asia/Shanghai","DE":"Europe/Berlin","EC":"America/Guayaquil","ES":"Europe/Madrid","MH":"Pacific/Majuro","MY":"Asia/Kuala_Lumpur","NZ":"Pacific/Auckland","PT":"Europe/Lisbon","UA":"Europe/Kiev","UZ":"Asia/Tashkent"}

--- a/tests/Calendar/CalendarTest.php
+++ b/tests/Calendar/CalendarTest.php
@@ -565,6 +565,10 @@ class CalendarTest extends PHPUnit_Framework_TestCase
         );
         $this->assertSame(
             '',
+            Calendar::getTimezoneNameNoLocationSpecific('invalid timezone')
+        );
+        $this->assertSame(
+            '',
             Calendar::getTimezoneNameNoLocationSpecific(false)
         );
         $this->assertSame(
@@ -669,6 +673,10 @@ class CalendarTest extends PHPUnit_Framework_TestCase
         $this->assertSame(
             '',
             Calendar::getTimezoneNameLocationSpecific('')
+        );
+        $this->assertSame(
+            '',
+            Calendar::getTimezoneNameLocationSpecific('invalid timezone')
         );
         $this->assertSame(
             '',

--- a/tests/Calendar/CalendarTest.php
+++ b/tests/Calendar/CalendarTest.php
@@ -328,6 +328,7 @@ class CalendarTest extends PHPUnit_Framework_TestCase
             array('format', array(Calendar::toDateTime('2010-01-02 08:01:02'), 'VVVVV'), '\\Punic\\Exception'),
             array('format', array(Calendar::toDateTime('2010-01-02 08:01:02'), 'XXXXXX'), '\\Punic\\Exception'),
             array('format', array(Calendar::toDateTime('2010-01-02 08:01:02'), 'xxxxxx'), '\\Punic\\Exception'),
+            array('getTimezoneNameLocationSpecific', array(1), '\\Punic\\Exception'),
             array('getWeekdayName', array(8), '\\Punic\\Exception'),
             array('getWeekdayName', array('test'), '\\Punic\\Exception'),
             array('getWeekdayName', array(1, 'invalid-width'), '\\Punic\\Exception'),
@@ -642,6 +643,86 @@ class CalendarTest extends PHPUnit_Framework_TestCase
         $this->assertSame(
             'Western European Standard Time',
             Calendar::getTimezoneNameNoLocationSpecific($dt, 'long')
+        );
+    }
+
+    public function testGetTimezoneNameLocationSpecific()
+    {
+        /* @var $dt \DateTime */
+        $dt = Calendar::toDateTime('2010-03-07');
+        $this->assertSame(
+            '',
+            Calendar::getTimezoneNameLocationSpecific(null)
+        );
+        $this->assertSame(
+            '',
+            Calendar::getTimezoneNameLocationSpecific('')
+        );
+        $this->assertSame(
+            '',
+            Calendar::getTimezoneNameLocationSpecific(false)
+        );
+        $this->assertSame(
+            'Fiji Time',
+            Calendar::getTimezoneNameLocationSpecific($dt)
+        );
+        $this->assertSame(
+            'Fiji Time',
+            Calendar::getTimezoneNameLocationSpecific($dt->getTimezone())
+        );
+        $this->assertSame(
+            'Fiji Time',
+            Calendar::getTimezoneNameLocationSpecific($dt->getTimezone()->getName())
+        );
+        $this->assertSame(
+            '',
+            Calendar::getTimezoneNameLocationSpecific('GMT')
+        );
+
+        $dt = Calendar::toDateTime('2000-01-01 11:12:13+14:15');
+        $this->assertSame(
+            '',
+            Calendar::getTimezoneNameLocationSpecific($dt)
+        );
+
+        // Timezone in primaryZones.json.
+        $dt = Calendar::toDateTime('2010-03-07', 'Europe/Berlin');
+        $this->assertSame(
+            'Germany Time',
+            Calendar::getTimezoneNameLocationSpecific($dt)
+        );
+        $this->assertSame(
+            'Germany Time',
+            Calendar::getTimezoneNameLocationSpecific($dt->getTimezone())
+        );
+        $this->assertSame(
+            'Germany Time',
+            Calendar::getTimezoneNameLocationSpecific($dt->getTimezone()->getName())
+        );
+
+        // Country with multiple timezones.
+        $dt = Calendar::toDateTime('2010-03-07', 'America/New_York');
+        $this->assertSame(
+            'New York Time',
+            Calendar::getTimezoneNameLocationSpecific($dt)
+        );
+        $this->assertSame(
+            'New York Time',
+            Calendar::getTimezoneNameLocationSpecific($dt->getTimezone())
+        );
+        $this->assertSame(
+            'New York Time',
+            Calendar::getTimezoneNameLocationSpecific($dt->getTimezone()->getName())
+        );
+
+        // Timezone with alias.
+        $this->assertSame(
+            'Atikokan Time',
+            Calendar::getTimezoneNameLocationSpecific('America/Atikokan')
+        );
+        $this->assertSame(
+            'Atikokan Time',
+            Calendar::getTimezoneNameLocationSpecific('America/Coral_Harbour')
         );
     }
 
@@ -1425,16 +1506,17 @@ class CalendarTest extends PHPUnit_Framework_TestCase
         $this->assertSame('GMT+13:00', Calendar::format($dt, 'OOOO'));
         $this->assertSame('UTC+13', Calendar::format($dt, 'O', 'fr'));
         // decodeTimezoneNoLocationGeneric
-        $this->assertSame('GMT+13:00', Calendar::format($dt, 'v'));
+        $this->assertSame('Fiji Time', Calendar::format($dt, 'v'));
         $this->assertSame('Fiji Time', Calendar::format($dt, 'vvvv'));
         $this->assertSame('GMT+14:15', Calendar::format(Calendar::toDateTime('2000-01-01 11:12:13+14:15'), 'vvvv'));
-        $this->assertSame('UTC+13:00', Calendar::format($dt, 'v', 'fr'));
+        $this->assertSame('heure : Fidji', Calendar::format($dt, 'v', 'fr'));
         $this->assertSame('heure des îles Fidji', Calendar::format($dt, 'vvvv', 'fr'));
         // decodeTimezoneID
         $this->assertSame('unk', Calendar::format($dt, 'V'));
         $this->assertSame('Pacific/Fiji', Calendar::format($dt, 'VV'));
         $this->assertSame('Fiji', Calendar::format($dt, 'VVV'));
-        $this->assertSame('GMT+13:00', Calendar::format($dt, 'VVVV'));
+        $this->assertSame('Fiji Time', Calendar::format($dt, 'VVVV'));
+        $this->assertSame('heure : Fidji', Calendar::format($dt, 'VVVV', 'fr'));
         // decodeTimezoneWithTime
         $this->assertSame('+13', Calendar::format($dt, 'x'));
         $this->assertSame('+1300', Calendar::format($dt, 'xx'));

--- a/tests/Calendar/CalendarTest.php
+++ b/tests/Calendar/CalendarTest.php
@@ -1333,6 +1333,8 @@ class CalendarTest extends PHPUnit_Framework_TestCase
         $dt = Calendar::toDateTime('2010-01-02 23:59:04.0123');
         $dt2 = Calendar::toDateTime('2010-01-02 08:01:02');
         $dt3 = Calendar::toDateTime('2010-12-31 08:01:02');
+        $dt4 = Calendar::toDateTime('2010-12-31 08:01:02', 'Etc/GMT-2');
+        $dt5 = Calendar::toDateTime('2010-12-31 08:01:02+02:00');
         $this->assertSame(
             '',
             Calendar::format(null, 'G')
@@ -1508,7 +1510,11 @@ class CalendarTest extends PHPUnit_Framework_TestCase
         $this->assertSame('GMT+13', Calendar::format($dt, 'z'));
         $this->assertSame('GMT+13', Calendar::format($dt, 'zz'));
         $this->assertSame('GMT+13', Calendar::format($dt, 'zzz'));
+        $this->assertSame('GMT+2', Calendar::format($dt4, 'z'));
+        $this->assertSame('GMT+2', Calendar::format($dt5, 'z'));
         $this->assertSame('Fiji Summer Time', Calendar::format($dt, 'zzzz'));
+        $this->assertSame('GMT+02:00', Calendar::format($dt4, 'zzzz'));
+        $this->assertSame('GMT+02:00', Calendar::format($dt5, 'zzzz'));
         $this->assertSame('Ora legale delle Figi', Calendar::format($dt, 'zzzz', 'it'));
         $this->assertSame('GMT-01:02', Calendar::format(Calendar::toDateTime('10/Oct/2000:13:55:36 -0102'), 'zzzz'));
         // decodeTimezoneDelta
@@ -1524,15 +1530,22 @@ class CalendarTest extends PHPUnit_Framework_TestCase
         $this->assertSame('UTC+13', Calendar::format($dt, 'O', 'fr'));
         // decodeTimezoneNoLocationGeneric
         $this->assertSame('Fiji Time', Calendar::format($dt, 'v'));
+        $this->assertSame('GMT+02:00', Calendar::format($dt4, 'v'));
+        $this->assertSame('GMT+02:00', Calendar::format($dt5, 'v'));
         $this->assertSame('Fiji Time', Calendar::format($dt, 'vvvv'));
+        $this->assertSame('GMT+02:00', Calendar::format($dt4, 'vvvv'));
+        $this->assertSame('GMT+02:00', Calendar::format($dt5, 'vvvv'));
         $this->assertSame('GMT+14:15', Calendar::format(Calendar::toDateTime('2000-01-01 11:12:13+14:15'), 'vvvv'));
         $this->assertSame('heure : Fidji', Calendar::format($dt, 'v', 'fr'));
         $this->assertSame('heure des îles Fidji', Calendar::format($dt, 'vvvv', 'fr'));
         // decodeTimezoneID
         $this->assertSame('unk', Calendar::format($dt, 'V'));
         $this->assertSame('Pacific/Fiji', Calendar::format($dt, 'VV'));
+        $this->assertSame('Etc/GMT-2', Calendar::format($dt4, 'VV'));
         $this->assertSame('Fiji', Calendar::format($dt, 'VVV'));
         $this->assertSame('Fiji Time', Calendar::format($dt, 'VVVV'));
+        $this->assertSame('GMT+02:00', Calendar::format($dt4, 'VVVV'));
+        $this->assertSame('GMT+02:00', Calendar::format($dt5, 'VVVV'));
         $this->assertSame('heure : Fidji', Calendar::format($dt, 'VVVV', 'fr'));
         // decodeTimezoneWithTime
         $this->assertSame('+13', Calendar::format($dt, 'x'));

--- a/tests/Calendar/CalendarTest.php
+++ b/tests/Calendar/CalendarTest.php
@@ -591,6 +591,18 @@ class CalendarTest extends PHPUnit_Framework_TestCase
             'GMT',
             Calendar::getTimezoneNameNoLocationSpecific('GMT', 'short')
         );
+
+        $dt = Calendar::toDateTime('2000-01-01 11:12:13', 'Etc/GMT+2');
+        $this->assertSame(
+            '',
+            Calendar::getTimezoneNameNoLocationSpecific($dt, 'long')
+        );
+        $dt = Calendar::toDateTime('2000-01-01 11:12:13+14:15');
+        $this->assertSame(
+            '',
+            Calendar::getTimezoneNameNoLocationSpecific($dt, 'long')
+        );
+
         $dt = Calendar::toDateTime('2010-03-07', 'Europe/Rome');
         $this->assertSame(
             'Central European Standard Time',
@@ -679,6 +691,11 @@ class CalendarTest extends PHPUnit_Framework_TestCase
             Calendar::getTimezoneNameLocationSpecific('GMT')
         );
 
+        $dt = Calendar::toDateTime('2000-01-01 11:12:13', 'Etc/GMT+2');
+        $this->assertSame(
+            '',
+            Calendar::getTimezoneNameLocationSpecific($dt)
+        );
         $dt = Calendar::toDateTime('2000-01-01 11:12:13+14:15');
         $this->assertSame(
             '',

--- a/tests/Calendar/CalendarTest.php
+++ b/tests/Calendar/CalendarTest.php
@@ -1510,7 +1510,7 @@ class CalendarTest extends PHPUnit_Framework_TestCase
         $this->assertSame('GMT+13', Calendar::format($dt, 'zzz'));
         $this->assertSame('Fiji Summer Time', Calendar::format($dt, 'zzzz'));
         $this->assertSame('Ora legale delle Figi', Calendar::format($dt, 'zzzz', 'it'));
-        $this->assertSame('GMT-1:02', Calendar::format(Calendar::toDateTime('10/Oct/2000:13:55:36 -0102'), 'zzzz'));
+        $this->assertSame('GMT-01:02', Calendar::format(Calendar::toDateTime('10/Oct/2000:13:55:36 -0102'), 'zzzz'));
         // decodeTimezoneDelta
         $this->assertSame('+1300', Calendar::format($dt, 'Z'));
         $this->assertSame('+1300', Calendar::format($dt, 'ZZ'));


### PR DESCRIPTION
This PR implements `Punic\Calendar::getTimezoneNameLocationSpecific()` based on the algorithm described in [UTS #35, part 2, 7.2, bullet 5](http://www.unicode.org/reports/tr35/tr35-dates.html#Time_Zone_Goals).