### PR TITLE
Run HHVM tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ sudo: false
 
 language: php
 
+dist: trusty
+
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         }
     },
     "require": {
-        "php": ">=5.3"
+        "php": ">=5.4"
     },
     "require-dev": {
         "apigen/apigen": "4.0.*"


### PR DESCRIPTION
Travis no longer supports HHVM on Debian Precise. This patch makes Travis use Debian Trusty instead.

PHP 5.3 is not supported on Trusty. PHP 5.3 reached its end-of-life in [mid-2014](http://php.net/supported-versions.php), so it seems reasonable to bump the PHP version requirement.

The oldest PHP version that has official support is 5.6, so we could bump the version even more.