### PR TITLE
Allow building with Docker

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,4 +8,4 @@
 /README.md
 /composer-travis-ci.json export-ignore
 
-.sh text eol=lf
+*.sh text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,5 @@
 /*.xml export-ignore
 /README.md
 /composer-travis-ci.json export-ignore
+
+.sh text eol=lf

--- a/bin/Dockerfile
+++ b/bin/Dockerfile
@@ -1,0 +1,15 @@
+FROM alpine:3.6
+
+RUN apk upgrade -U && \
+    apk add --update --no-cache \
+        subversion \
+        openjdk8 \
+        apache-ant \
+        php7 \
+        php7-json
+
+ENV PATH=$PATH:/punic/bin
+
+WORKDIR /punic
+
+CMD /punic/bin/build.sh

--- a/bin/build-docker.cmd
+++ b/bin/build-docker.cmd
@@ -1,5 +1,5 @@
 @echo off
 
-docker-compose -f "%~dp0docker-compose.yml" run punic dos2unix /punic/bin/build.sh
+docker-compose -f "%~dp0docker-compose.yml" run --rm punic dos2unix /punic/bin/build.sh
 
-docker-compose -f "%~dp0docker-compose.yml" run punic build.sh %*
+docker-compose -f "%~dp0docker-compose.yml" run --rm punic build.sh %*

--- a/bin/build-docker.cmd
+++ b/bin/build-docker.cmd
@@ -1,5 +1,5 @@
 @echo off
 
-docker-compose -f "%~dp0docker-compose.yml" run punic sed -i -e 's/\r//g' /punic/bin/build.sh
+docker-compose -f "%~dp0docker-compose.yml" run punic dos2unix /punic/bin/build.sh
 
 docker-compose -f "%~dp0docker-compose.yml" run punic build.sh %*

--- a/bin/build-docker.cmd
+++ b/bin/build-docker.cmd
@@ -1,0 +1,3 @@
+@echo off
+
+docker-compose -f "%~dp0docker-compose.yml" run punic build.sh %*

--- a/bin/build-docker.cmd
+++ b/bin/build-docker.cmd
@@ -1,3 +1,5 @@
 @echo off
 
+docker-compose -f "%~dp0docker-compose.yml" run punic sed -i -e 's/\r//g' /punic/bin/build.sh
+
 docker-compose -f "%~dp0docker-compose.yml" run punic build.sh %*

--- a/bin/build-docker.sh
+++ b/bin/build-docker.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+docker-compose -f "$(dirname -- "$0")/docker-compose.yml" run punic build.sh $@

--- a/bin/build-docker.sh
+++ b/bin/build-docker.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-docker-compose -f "$(dirname -- "$0")/docker-compose.yml" run punic build.sh $@
+docker-compose -f "$(dirname -- "$0")/docker-compose.yml" run --rm punic build.sh $@

--- a/bin/docker-compose.yml
+++ b/bin/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '2'
+
+services:
+    punic:
+        build: .
+        volumes:
+            - ..:/punic


### PR DESCRIPTION
Building the data files requires Java and other evil. To make it easier to get a build environment up and running, and to avoid polluting your computer with all the build requirements, this PR adds support for building inside a [Docker](https://www.docker.com/) container.

Building data files is not only relevant for contributors to this library but also for people who need other locales than those included by default.

For people who already have Docker installed, they should simply run `bin/build-docker.sh`. It accepts the same parameters as `bin/build.sh`.

The script for Windows, `bin/build-docker.sh`, was writted based on `bin/build.cmd`, but I don't have a Windows box to test it on, so I hope someone else will do this and fix any bugs. 

I am not sure if building the files is even necessary anymore, now that the JSON files are generated and [published on Github](https://github.com/unicode-cldr/) by the CLDR project, but I haven't looked into that.
