### PR TITLE
Support string quantity

### DIFF
--- a/code/Currency.php
+++ b/code/Currency.php
@@ -70,7 +70,7 @@ class Currency
         if (is_array($data)) {
             $result = $data['name'];
             if (($quantity !== null) && isset($data['pluralName'])) {
-                if (is_string($data) && in_array($quantity, array('zero', 'one', 'two', 'few', 'many', 'other'))) {
+                if (in_array($quantity, array('zero', 'one', 'two', 'few', 'many', 'other'))) {
                     $pluralRule = $quantity;
                 } else {
                     $pluralRule = Plural::getRule($quantity, $locale);

--- a/tests/Currency/CurrencyTest.php
+++ b/tests/Currency/CurrencyTest.php
@@ -27,6 +27,8 @@ class CurrencyTest extends PHPUnit_Framework_TestCase
             array('en', 'USD', 0, 'US dollars', '$', '$', ''),
             array('en', 'USD', 1, 'US dollar', '$', '$', ''),
             array('en', 'USD', 2, 'US dollars', '$', '$', ''),
+            array('en', 'USD', 'one', 'US dollar', '$', '$', ''),
+            array('en', 'USD', 'many', 'US dollars', '$', '$', ''),
         );
     }
 


### PR DESCRIPTION
According to the [documentation for `Currency::getName()`](http://punic.github.io/docs/class-Punic.Currency.html#_getName), you can pass one of the enumerated plural strings (zero, one, few, many, etc.) as the second argument.

This does not work, but throws an exception: `Punic\Exception\BadArgumentType: Can't convert 'one' to a number`.