### PR TITLE
Support or-separated lists

### DIFF
--- a/src/Misc.php
+++ b/src/Misc.php
@@ -8,7 +8,72 @@ namespace Punic;
 class Misc
 {
     /**
-     * Concatenates a list of items returning a localized string (for instance: array(1, 2, 3) will result in '1, 2, and 3' for English or '1, 2 e 3' for Italian).
+     * Concatenates a list of items returning a localized string using "and" as seperator.
+     *
+     * For instance, array(1, 2, 3) will result in '1, 2, and 3' for English or '1, 2 e 3' for Italian.
+     *
+     * @param array $list The list to concatenate
+     * @param string $locale The locale to use. If empty we'll use the default locale set in \Punic\Data
+     *
+     * @return string returns an empty string if $list is not an array of it it's empty, the joined items otherwise
+     *
+     * @deprecated use joinAnd()
+     */
+    public static function join($list, $locale = '')
+    {
+        return static::joinList($list, 'standard', '', $locale);
+    }
+
+    /**
+     * Concatenates a list of items returning a localized string using "and" as seperator.
+     *
+     * For instance, array(1, 2, 3) will result in '1, 2, and 3' for English or '1, 2 e 3' for Italian.
+     *
+     * @param array $list The list to concatenate
+     * @param string $width The preferred width ('' for default, or 'short' or 'narrow')
+     * @param string $locale The locale to use. If empty we'll use the default locale set in \Punic\Data
+     *
+     * @return string returns an empty string if $list is not an array of it it's empty, the joined items otherwise
+     */
+    public static function joinAnd($list, $width = '', $locale = '')
+    {
+        return static::joinList($list, 'standard', $width, $locale);
+    }
+
+    /**
+     * Concatenates a list of items returning a localized string using "or" as seperator.
+     *
+     * For instance, array(1, 2, 3) will result in '1, 2, or 3' for English or '1, 2 o 3' for Italian.
+     *
+     * @param array $list The list to concatenate
+     * @param string $width The preferred width ('' for default, or 'short' or 'narrow')
+     * @param string $locale The locale to use. If empty we'll use the default locale set in \Punic\Data
+     *
+     * @return string returns an empty string if $list is not an array of it it's empty, the joined items otherwise
+     */
+    public static function joinOr($list, $width = '', $locale = '')
+    {
+        return static::joinList($list, 'or', $width, $locale);
+    }
+
+    /**
+     * Concatenates a list of unit items returning a localized string.
+     *
+     * For instance, array('3 ft', '2 in') will result in '3 ft, 2 in'.
+     *
+     * @param array $list The list to concatenate
+     * @param string $width The preferred width ('' for default, or 'short' or 'narrow')
+     * @param string $locale The locale to use. If empty we'll use the default locale set in \Punic\Data
+     *
+     * @return string returns an empty string if $list is not an array of it it's empty, the joined items otherwise
+     */
+    public static function joinUnits($list, $width = '', $locale = '')
+    {
+        return static::joinList($list, 'unit', $width, $locale);
+    }
+
+    /**
+     * Concatenates a list of items returning a localized string.
      *
      * @param array $list The list to concatenate
      * @param string $type The type of list; 'standard' (e.g. '1, 2, and 3'), 'or' ('1, 2, or 3') or 'unit' ('3 ft, 2 in').
@@ -17,7 +82,7 @@ class Misc
      *
      * @return string returns an empty string if $list is not an array of it it's empty, the joined items otherwise
      */
-    public static function list($list, $type = 'standard', $width = '', $locale = '')
+    public static function joinList($list, $type = 'standard', $width = '', $locale = '')
     {
         $result = '';
         if (is_array($list)) {
@@ -73,37 +138,6 @@ class Misc
         }
 
         return $result;
-    }
-
-    /**
-     * Concatenates a list of items returning a localized string (for instance: array(1, 2, 3) will result in '1, 2, and 3' for English or '1, 2 e 3' for Italian).
-     *
-     * @param array $list The list to concatenate
-     * @param string $locale The locale to use. If empty we'll use the default locale set in \Punic\Data
-     *
-     * @return string returns an empty string if $list is not an array of it it's empty, the joined items otherwise
-     *
-     * @deprecated Use list() instead.
-     */
-    public static function join($list, $locale = '')
-    {
-        return static::list($list, 'standard', '', $locale);
-    }
-
-    /**
-     * Concatenates a list of unit items returning a localized string (for instance: array('3 ft', '2 in') will result in '3 ft, 2 in'.
-     *
-     * @param array $list The list to concatenate
-     * @param string $width The preferred width ('' for default, or 'short' or 'narrow')
-     * @param string $locale The locale to use. If empty we'll use the default locale set in \Punic\Data
-     *
-     * @return string returns an empty string if $list is not an array of it it's empty, the joined items otherwise
-     *
-     * @deprecated Use list() instead.
-     */
-    public static function joinUnits($list, $width = '', $locale = '')
-    {
-        return static::list($list, 'unit', $width, $locale);
     }
 
     /**

--- a/src/Misc.php
+++ b/src/Misc.php
@@ -112,14 +112,14 @@ class Misc
                     $allData = Data::get('listPatterns', $locale);
                     $data = null;
                     foreach ($suffixes as $suffix) {
-                        $key = $type . $suffix;
+                        $key = $type.$suffix;
                         if (isset($allData[$key])) {
                             $data = $allData[$key];
                             break;
                         }
                     }
                     if ($data === null) {
-                        $types = array_unique(array_map(function($key) { return strtok($key, '-'); }, array_keys($allData)));
+                        $types = array_unique(array_map(function ($key) { return strtok($key, '-'); }, array_keys($allData)));
                         throw new \Punic\Exception\ValueNotInList($type, $types);
                     }
                     if (isset($data[$n])) {

--- a/tests/Misc/ListTest.php
+++ b/tests/Misc/ListTest.php
@@ -4,6 +4,131 @@ use Punic\Misc;
 
 class ListTest extends PHPUnit_Framework_TestCase
 {
+    public function testList()
+    {
+        $this->assertSame(
+            '',
+            Misc::list(false, 'standard', '', 'en')
+        );
+        $this->assertSame(
+            '',
+            Misc::list('', 'standard', '', 'en')
+        );
+        $this->assertSame(
+            '',
+            Misc::list(array(), 'standard', '', 'en')
+        );
+        $this->assertSame(
+            '',
+            Misc::list(false, 'or', '', 'en')
+        );
+        $this->assertSame(
+            '',
+            Misc::list('', 'or', '', 'en')
+        );
+        $this->assertSame(
+            '',
+            Misc::list(array(), 'or', '', 'en')
+        );
+        $this->assertSame(
+            'One',
+            Misc::list(array('One'), 'standard', '', 'en')
+        );
+        $this->assertSame(
+            'One',
+            Misc::list(array('One'), 'or', '', 'en')
+        );
+        $this->assertSame(
+            'One and Two',
+            Misc::list(array('One', 'Two'), 'standard', '', 'en')
+        );
+        $this->assertSame(
+            'One and Two',
+            Misc::list(array('One', 'Two'), 'standard', 'short', 'en')
+        );
+        $this->assertSame(
+            'One and Two',
+            Misc::list(array('One', 'Two'), 'standard', 'narrow', 'en')
+        );
+        $this->assertSame(
+            'One or Two',
+            Misc::list(array('One', 'Two'), 'or', '', 'en')
+        );
+        $this->assertSame(
+            'One, Two, and Three',
+            Misc::list(array('One', 'Two', 'Three'), 'standard', '', 'en')
+        );
+        $this->assertSame(
+            'One, Two and Three',
+            Misc::list(array('One', 'Two', 'Three'), 'standard', '', 'en_GB')
+        );
+        $this->assertSame(
+            'One, Two, or Three',
+            Misc::list(array('One', 'Two', 'Three'), 'or', '', 'en')
+        );
+        $this->assertSame(
+            'One, Two, Three, and Four',
+            Misc::list(array('One', 'Two', 'Three', 'Four'), 'standard', '', 'en')
+        );
+        $this->assertSame(
+            'One, Two, Three, or Four',
+            Misc::list(array('One', 'Two', 'Three', 'Four'), 'or', '', 'en')
+        );
+        $this->assertSame(
+            'One, Two, Three, Four, and 5',
+            Misc::list(array('One', 'Two', 'Three', 'Four', 5), 'standard', '', 'en')
+        );
+        $this->assertSame(
+            'Uno',
+            Misc::list(array('Uno'), 'standard', '', 'it')
+        );
+        $this->assertSame(
+            'Uno e due',
+            Misc::list(array('Uno', 'due'), 'standard', '', 'it')
+        );
+        $this->assertSame(
+            'Uno o due',
+            Misc::list(array('Uno', 'due'), 'or', '', 'it')
+        );
+        $this->assertSame(
+            'Uno, due e tre',
+            Misc::list(array('Uno', 'due', 'tre'), 'standard', '', 'it')
+        );
+        $this->assertSame(
+            'Uno, due, tre e quattro',
+            Misc::list(array('Uno', 'due', 'tre', 'quattro'), 'standard', '', 'it')
+        );
+        $this->assertSame(
+            'Uno, due, tre, quattro e 5',
+            Misc::list(array('Uno', 'due', 'tre', 'quattro', 5), 'standard', '', 'it')
+        );
+
+        $this->assertSame(
+            '1 ft, 3 in',
+            Misc::list(array('1 ft', '3 in'), 'unit', '', 'en')
+        );
+        $this->assertSame(
+            '1 ft, 3 in',
+            Misc::list(array('1 ft', '3 in'), 'unit', 'short', 'en')
+        );
+        $this->assertSame(
+            '1 ft 3 in',
+            Misc::list(array('1 ft', '3 in'), 'unit', 'narrow', 'en')
+        );
+        $this->assertSame(
+            '1 piede e 3 pollici',
+            Misc::list(array('1 piede', '3 pollici'), 'unit', '', 'it')
+        );
+        $this->assertSame(
+            '1 piede e 3 pollici',
+            Misc::list(array('1 piede', '3 pollici'), 'unit', 'short', 'it')
+        );
+        $this->assertSame(
+            '1 piede 3 pollici',
+            Misc::list(array('1 piede', '3 pollici'), 'unit', 'narrow', 'it')
+        );
+    }
+
     public function testJoin()
     {
         $this->assertSame(
@@ -132,10 +257,16 @@ class ListTest extends PHPUnit_Framework_TestCase
         );
     }
 
-    public function testValueNotInListException()
+    public function testInvalidType()
     {
-        $this->setExpectedException('\\Punic\\Exception\\ValueNotInList');
-        Misc::joinUnits(array('One', 'Two'), 'invalid-width', 'en');
+        $this->setExpectedException('\\Punic\\Exception\\ValueNotInList', "'invalid-type' is not valid. Acceptable values are: 'standard', 'or', 'unit");
+        Misc::list(array('One', 'Two'), 'invalid-type', '', 'en');
+    }
+
+    public function testInvalidWidthException()
+    {
+        $this->setExpectedException('\\Punic\\Exception\\ValueNotInList', "'invalid-width' is not valid. Acceptable values are: '', 'short', 'narrow'");
+        Misc::list(array('One', 'Two'), '', 'invalid-width', 'en');
     }
 
     /**

--- a/tests/Misc/ListTest.php
+++ b/tests/Misc/ListTest.php
@@ -241,79 +241,10 @@ class ListTest extends PHPUnit_Framework_TestCase
         );
     }
 
-    public function testJoinList()
-    {
-        $this->assertSame(
-            '',
-            Misc::joinList(false, 'standard', '', 'en')
-        );
-        $this->assertSame(
-            '',
-            Misc::joinList('', 'or', '', 'en')
-        );
-        $this->assertSame(
-            '',
-            Misc::joinList(array(), 'unit', '', 'en')
-        );
-        $this->assertSame(
-            'One',
-            Misc::joinList(array('One'), 'standard', '', 'en')
-        );
-        $this->assertSame(
-            'One',
-            Misc::joinList(array('One'), 'or', '', 'en')
-        );
-        $this->assertSame(
-            'One and Two',
-            Misc::joinList(array('One', 'Two'), 'standard', '', 'en')
-        );
-        $this->assertSame(
-            'One and Two',
-            Misc::joinList(array('One', 'Two'), 'standard', 'short', 'en')
-        );
-        $this->assertSame(
-            'One and Two',
-            Misc::joinList(array('One', 'Two'), 'standard', 'narrow', 'en')
-        );
-        $this->assertSame(
-            'One, Two, or Three',
-            Misc::joinList(array('One', 'Two', 'Three'), 'or', '', 'en')
-        );
-        $this->assertSame(
-            'Uno e due',
-            Misc::joinList(array('Uno', 'due'), 'standard', '', 'it')
-        );
-
-        $this->assertSame(
-            '1 ft, 3 in',
-            Misc::joinList(array('1 ft', '3 in'), 'unit', '', 'en')
-        );
-        $this->assertSame(
-            '1 ft, 3 in',
-            Misc::joinList(array('1 ft', '3 in'), 'unit', 'short', 'en')
-        );
-        $this->assertSame(
-            '1 ft 3 in',
-            Misc::joinList(array('1 ft', '3 in'), 'unit', 'narrow', 'en')
-        );
-
-        Data::setDefaultLocale('de');
-        $this->assertSame(
-            'Eins und zwei',
-            Misc::joinList(array('Eins', 'zwei'))
-        );
-    }
-
-    public function testInvalidType()
-    {
-        $this->setExpectedException('\\Punic\\Exception\\ValueNotInList', "'invalid-type' is not valid. Acceptable values are: 'standard', 'or', 'unit");
-        Misc::joinList(array('One', 'Two'), 'invalid-type', '', 'en');
-    }
-
     public function testInvalidWidthException()
     {
         $this->setExpectedException('\\Punic\\Exception\\ValueNotInList', "'invalid-width' is not valid. Acceptable values are: '', 'short', 'narrow'");
-        Misc::joinList(array('One', 'Two'), '', 'invalid-width', 'en');
+        Misc::joinAnd(array('One', 'Two'), 'invalid-width', 'en');
     }
 
     /**

--- a/tests/Misc/ListTest.php
+++ b/tests/Misc/ListTest.php
@@ -1,134 +1,10 @@
 <?php
 
+use Punic\Data;
 use Punic\Misc;
 
 class ListTest extends PHPUnit_Framework_TestCase
 {
-    public function testList()
-    {
-        $this->assertSame(
-            '',
-            Misc::list(false, 'standard', '', 'en')
-        );
-        $this->assertSame(
-            '',
-            Misc::list('', 'standard', '', 'en')
-        );
-        $this->assertSame(
-            '',
-            Misc::list(array(), 'standard', '', 'en')
-        );
-        $this->assertSame(
-            '',
-            Misc::list(false, 'or', '', 'en')
-        );
-        $this->assertSame(
-            '',
-            Misc::list('', 'or', '', 'en')
-        );
-        $this->assertSame(
-            '',
-            Misc::list(array(), 'or', '', 'en')
-        );
-        $this->assertSame(
-            'One',
-            Misc::list(array('One'), 'standard', '', 'en')
-        );
-        $this->assertSame(
-            'One',
-            Misc::list(array('One'), 'or', '', 'en')
-        );
-        $this->assertSame(
-            'One and Two',
-            Misc::list(array('One', 'Two'), 'standard', '', 'en')
-        );
-        $this->assertSame(
-            'One and Two',
-            Misc::list(array('One', 'Two'), 'standard', 'short', 'en')
-        );
-        $this->assertSame(
-            'One and Two',
-            Misc::list(array('One', 'Two'), 'standard', 'narrow', 'en')
-        );
-        $this->assertSame(
-            'One or Two',
-            Misc::list(array('One', 'Two'), 'or', '', 'en')
-        );
-        $this->assertSame(
-            'One, Two, and Three',
-            Misc::list(array('One', 'Two', 'Three'), 'standard', '', 'en')
-        );
-        $this->assertSame(
-            'One, Two and Three',
-            Misc::list(array('One', 'Two', 'Three'), 'standard', '', 'en_GB')
-        );
-        $this->assertSame(
-            'One, Two, or Three',
-            Misc::list(array('One', 'Two', 'Three'), 'or', '', 'en')
-        );
-        $this->assertSame(
-            'One, Two, Three, and Four',
-            Misc::list(array('One', 'Two', 'Three', 'Four'), 'standard', '', 'en')
-        );
-        $this->assertSame(
-            'One, Two, Three, or Four',
-            Misc::list(array('One', 'Two', 'Three', 'Four'), 'or', '', 'en')
-        );
-        $this->assertSame(
-            'One, Two, Three, Four, and 5',
-            Misc::list(array('One', 'Two', 'Three', 'Four', 5), 'standard', '', 'en')
-        );
-        $this->assertSame(
-            'Uno',
-            Misc::list(array('Uno'), 'standard', '', 'it')
-        );
-        $this->assertSame(
-            'Uno e due',
-            Misc::list(array('Uno', 'due'), 'standard', '', 'it')
-        );
-        $this->assertSame(
-            'Uno o due',
-            Misc::list(array('Uno', 'due'), 'or', '', 'it')
-        );
-        $this->assertSame(
-            'Uno, due e tre',
-            Misc::list(array('Uno', 'due', 'tre'), 'standard', '', 'it')
-        );
-        $this->assertSame(
-            'Uno, due, tre e quattro',
-            Misc::list(array('Uno', 'due', 'tre', 'quattro'), 'standard', '', 'it')
-        );
-        $this->assertSame(
-            'Uno, due, tre, quattro e 5',
-            Misc::list(array('Uno', 'due', 'tre', 'quattro', 5), 'standard', '', 'it')
-        );
-
-        $this->assertSame(
-            '1 ft, 3 in',
-            Misc::list(array('1 ft', '3 in'), 'unit', '', 'en')
-        );
-        $this->assertSame(
-            '1 ft, 3 in',
-            Misc::list(array('1 ft', '3 in'), 'unit', 'short', 'en')
-        );
-        $this->assertSame(
-            '1 ft 3 in',
-            Misc::list(array('1 ft', '3 in'), 'unit', 'narrow', 'en')
-        );
-        $this->assertSame(
-            '1 piede e 3 pollici',
-            Misc::list(array('1 piede', '3 pollici'), 'unit', '', 'it')
-        );
-        $this->assertSame(
-            '1 piede e 3 pollici',
-            Misc::list(array('1 piede', '3 pollici'), 'unit', 'short', 'it')
-        );
-        $this->assertSame(
-            '1 piede 3 pollici',
-            Misc::list(array('1 piede', '3 pollici'), 'unit', 'narrow', 'it')
-        );
-    }
-
     public function testJoin()
     {
         $this->assertSame(
@@ -136,52 +12,160 @@ class ListTest extends PHPUnit_Framework_TestCase
             Misc::join(false, 'en')
         );
         $this->assertSame(
-            '',
-            Misc::join('', 'en')
-        );
-        $this->assertSame(
-            '',
-            Misc::join(array(), 'en')
-        );
-        $this->assertSame(
-            'One',
-            Misc::join(array('One'), 'en')
-        );
-        $this->assertSame(
             'One and Two',
             Misc::join(array('One', 'Two'), 'en')
-        );
-        $this->assertSame(
-            'One, Two, and Three',
-            Misc::join(array('One', 'Two', 'Three'), 'en')
-        );
-        $this->assertSame(
-            'One, Two, Three, and Four',
-            Misc::join(array('One', 'Two', 'Three', 'Four'), 'en')
-        );
-        $this->assertSame(
-            'One, Two, Three, Four, and 5',
-            Misc::join(array('One', 'Two', 'Three', 'Four', 5), 'en')
-        );
-        $this->assertSame(
-            'Uno',
-            Misc::join(array('Uno'), 'it')
         );
         $this->assertSame(
             'Uno e due',
             Misc::join(array('Uno', 'due'), 'it')
         );
+    }
+
+    public function testJoinAnd()
+    {
+        $this->assertSame(
+            '',
+            Misc::joinAnd(false, '', 'en')
+        );
+        $this->assertSame(
+            '',
+            Misc::joinAnd('', '', 'en')
+        );
+        $this->assertSame(
+            '',
+            Misc::joinAnd(array(), '', 'en')
+        );
+        $this->assertSame(
+            'One',
+            Misc::joinAnd(array('One'), '', 'en')
+        );
+        $this->assertSame(
+            'One and Two',
+            Misc::joinAnd(array('One', 'Two'), '', 'en')
+        );
+        $this->assertSame(
+            'One, Two, and Three',
+            Misc::joinAnd(array('One', 'Two', 'Three'), '', 'en')
+        );
+        $this->assertSame(
+            'One, Two, and Three',
+            Misc::joinAnd(array('One', 'Two', 'Three'), 'short', 'en')
+        );
+        $this->assertSame(
+            'One, Two, and Three',
+            Misc::joinAnd(array('One', 'Two', 'Three'), 'narrow', 'en')
+        );
+        $this->assertSame(
+            'One, Two and Three',
+            Misc::joinAnd(array('One', 'Two', 'Three'), '', 'en-GB')
+        );
+        $this->assertSame(
+            'One, Two, Three, and Four',
+            Misc::joinAnd(array('One', 'Two', 'Three', 'Four'), '', 'en')
+        );
+        $this->assertSame(
+            'One, Two, Three, Four, and 5',
+            Misc::joinAnd(array('One', 'Two', 'Three', 'Four', 5), '', 'en')
+        );
+        $this->assertSame(
+            'Uno',
+            Misc::joinAnd(array('Uno'), '', 'it')
+        );
+        $this->assertSame(
+            'Uno e due',
+            Misc::joinAnd(array('Uno', 'due'), '', 'it')
+        );
         $this->assertSame(
             'Uno, due e tre',
-            Misc::join(array('Uno', 'due', 'tre'), 'it')
+            Misc::joinAnd(array('Uno', 'due', 'tre'), '', 'it')
         );
         $this->assertSame(
             'Uno, due, tre e quattro',
-            Misc::join(array('Uno', 'due', 'tre', 'quattro'), 'it')
+            Misc::joinAnd(array('Uno', 'due', 'tre', 'quattro'), '', 'it')
         );
         $this->assertSame(
             'Uno, due, tre, quattro e 5',
-            Misc::join(array('Uno', 'due', 'tre', 'quattro', 5), 'it')
+            Misc::joinAnd(array('Uno', 'due', 'tre', 'quattro', 5), '', 'it')
+        );
+
+        Data::setDefaultLocale('de');
+        $this->assertSame(
+            'Eins und zwei',
+            Misc::joinAnd(array('Eins', 'zwei'))
+        );
+    }
+
+    public function testJoinOr()
+    {
+        $this->assertSame(
+            '',
+            Misc::joinOr(false, '', 'en')
+        );
+        $this->assertSame(
+            '',
+            Misc::joinOr('', '', 'en')
+        );
+        $this->assertSame(
+            '',
+            Misc::joinOr(array(), '', 'en')
+        );
+        $this->assertSame(
+            'One',
+            Misc::joinOr(array('One'), '', 'en')
+        );
+        $this->assertSame(
+            'One or Two',
+            Misc::joinOr(array('One', 'Two'), '', 'en')
+        );
+        $this->assertSame(
+            'One, Two, or Three',
+            Misc::joinOr(array('One', 'Two', 'Three'), '', 'en')
+        );
+        $this->assertSame(
+            'One, Two, or Three',
+            Misc::joinOr(array('One', 'Two', 'Three'), 'short', 'en')
+        );
+        $this->assertSame(
+            'One, Two, or Three',
+            Misc::joinOr(array('One', 'Two', 'Three'), 'narrow', 'en')
+        );
+        $this->assertSame(
+            'One, Two or Three',
+            Misc::joinOr(array('One', 'Two', 'Three'), '', 'en-GB')
+        );
+        $this->assertSame(
+            'One, Two, Three, or Four',
+            Misc::joinOr(array('One', 'Two', 'Three', 'Four'), '', 'en')
+        );
+        $this->assertSame(
+            'One, Two, Three, Four, or 5',
+            Misc::joinOr(array('One', 'Two', 'Three', 'Four', 5), '', 'en')
+        );
+        $this->assertSame(
+            'Uno',
+            Misc::joinOr(array('Uno'), '', 'it')
+        );
+        $this->assertSame(
+            'Uno o due',
+            Misc::joinOr(array('Uno', 'due'), '', 'it')
+        );
+        $this->assertSame(
+            'Uno, due o tre',
+            Misc::joinOr(array('Uno', 'due', 'tre'), '', 'it')
+        );
+        $this->assertSame(
+            'Uno, due, tre o quattro',
+            Misc::joinOr(array('Uno', 'due', 'tre', 'quattro'), '', 'it')
+        );
+        $this->assertSame(
+            'Uno, due, tre, quattro o 5',
+            Misc::joinOr(array('Uno', 'due', 'tre', 'quattro', 5), '', 'it')
+        );
+
+        Data::setDefaultLocale('de');
+        $this->assertSame(
+            'Eins oder zwei',
+            Misc::joinOr(array('Eins', 'zwei'))
         );
     }
 
@@ -257,16 +241,79 @@ class ListTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    public function testJoinList()
+    {
+        $this->assertSame(
+            '',
+            Misc::joinList(false, 'standard', '', 'en')
+        );
+        $this->assertSame(
+            '',
+            Misc::joinList('', 'or', '', 'en')
+        );
+        $this->assertSame(
+            '',
+            Misc::joinList(array(), 'unit', '', 'en')
+        );
+        $this->assertSame(
+            'One',
+            Misc::joinList(array('One'), 'standard', '', 'en')
+        );
+        $this->assertSame(
+            'One',
+            Misc::joinList(array('One'), 'or', '', 'en')
+        );
+        $this->assertSame(
+            'One and Two',
+            Misc::joinList(array('One', 'Two'), 'standard', '', 'en')
+        );
+        $this->assertSame(
+            'One and Two',
+            Misc::joinList(array('One', 'Two'), 'standard', 'short', 'en')
+        );
+        $this->assertSame(
+            'One and Two',
+            Misc::joinList(array('One', 'Two'), 'standard', 'narrow', 'en')
+        );
+        $this->assertSame(
+            'One, Two, or Three',
+            Misc::joinList(array('One', 'Two', 'Three'), 'or', '', 'en')
+        );
+        $this->assertSame(
+            'Uno e due',
+            Misc::joinList(array('Uno', 'due'), 'standard', '', 'it')
+        );
+
+        $this->assertSame(
+            '1 ft, 3 in',
+            Misc::joinList(array('1 ft', '3 in'), 'unit', '', 'en')
+        );
+        $this->assertSame(
+            '1 ft, 3 in',
+            Misc::joinList(array('1 ft', '3 in'), 'unit', 'short', 'en')
+        );
+        $this->assertSame(
+            '1 ft 3 in',
+            Misc::joinList(array('1 ft', '3 in'), 'unit', 'narrow', 'en')
+        );
+
+        Data::setDefaultLocale('de');
+        $this->assertSame(
+            'Eins und zwei',
+            Misc::joinList(array('Eins', 'zwei'))
+        );
+    }
+
     public function testInvalidType()
     {
         $this->setExpectedException('\\Punic\\Exception\\ValueNotInList', "'invalid-type' is not valid. Acceptable values are: 'standard', 'or', 'unit");
-        Misc::list(array('One', 'Two'), 'invalid-type', '', 'en');
+        Misc::joinList(array('One', 'Two'), 'invalid-type', '', 'en');
     }
 
     public function testInvalidWidthException()
     {
         $this->setExpectedException('\\Punic\\Exception\\ValueNotInList', "'invalid-width' is not valid. Acceptable values are: '', 'short', 'narrow'");
-        Misc::list(array('One', 'Two'), '', 'invalid-width', 'en');
+        Misc::joinList(array('One', 'Two'), '', 'invalid-width', 'en');
     }
 
     /**


### PR DESCRIPTION
CLDR 32 added a new “disjunctive” list style (e.g. “1, 2, or 3”).

This PR deprecated `Misc::join()` and `Misc::joinUnits()` into on general list joining function that supports “and“, “or” and “units”.

The tests will fail until Punic has been upgraded to CLDR 32.