### PR TITLE
Allow using custom data directory

### DIFF
--- a/src/Data.php
+++ b/src/Data.php
@@ -141,6 +141,8 @@ class Data
     public static function setDataDirectory($directory)
     {
         static::$directory = $directory;
+
+        static::$cache = array();
     }
 
     /**

--- a/src/Data.php
+++ b/src/Data.php
@@ -40,7 +40,7 @@ class Data
      *
      * @var string
      */
-    protected static $directory = __DIR__.DIRECTORY_SEPARATOR.'data';
+    protected static $directory;
 
     /**
      * Return the current default locale.
@@ -126,6 +126,10 @@ class Data
      */
     public static function getDataDirectory()
     {
+        if (!isset(static::$directory)) {
+            static::$directory = __DIR__.DIRECTORY_SEPARATOR.'data';
+        }
+
         return static::$directory;
     }
 
@@ -170,7 +174,7 @@ class Data
             if ($dir === '') {
                 throw new Exception\DataFolderNotFound($locale, static::$fallbackLocale);
             }
-            $file = self::$directory.DIRECTORY_SEPARATOR.$dir.DIRECTORY_SEPARATOR.$identifier.'.php';
+            $file = static::getDataDirectory().DIRECTORY_SEPARATOR.$dir.DIRECTORY_SEPARATOR.$identifier.'.php';
             if (!is_file($file)) {
                 throw new Exception\DataFileNotFound($identifier, $locale, static::$fallbackLocale);
             }
@@ -209,7 +213,7 @@ class Data
         if (!preg_match('/^[a-zA-Z0-9_\\-]+$/', $identifier)) {
             throw new Exception\InvalidDataFile($identifier);
         }
-        $file = self::$directory.DIRECTORY_SEPARATOR."$identifier.php";
+        $file = static::getDataDirectory().DIRECTORY_SEPARATOR."$identifier.php";
         if (!is_file($file)) {
             throw new Exception\DataFileNotFound($identifier);
         }
@@ -235,7 +239,7 @@ class Data
     public static function getAvailableLocales($allowGroups = false)
     {
         $locales = array();
-        $dir = self::$directory;
+        $dir = static::getDataDirectory();
         if (is_dir($dir) && is_readable($dir)) {
             $contents = @scandir($dir);
             if (is_array($contents)) {
@@ -521,8 +525,9 @@ class Data
         if (is_string($locale)) {
             $key = $locale.'/'.static::$fallbackLocale;
             if (!isset($cache[$key])) {
+                $dir = static::getDataDirectory();
                 foreach (static::getLocaleAlternatives($locale) as $alternative) {
-                    if (is_dir(self::$directory.DIRECTORY_SEPARATOR.$alternative)) {
+                    if (is_dir($dir.DIRECTORY_SEPARATOR.$alternative)) {
                         $result = $alternative;
                         break;
                     }

--- a/src/Data.php
+++ b/src/Data.php
@@ -36,6 +36,13 @@ class Data
     protected static $fallbackLocale = 'en_US';
 
     /**
+     * The data root directory.
+     *
+     * @var string
+     */
+    protected static $directory = __DIR__.DIRECTORY_SEPARATOR.'data';
+
+    /**
      * Return the current default locale.
      *
      * @return string
@@ -113,6 +120,26 @@ class Data
     }
 
     /**
+     * Get the data root directory.
+     *
+     * @return string
+     */
+    public static function getDataDirectory()
+    {
+        return static::$directory;
+    }
+
+    /**
+     * Set the data root directory.
+     *
+     * @param string $directory
+     */
+    public static function setDataDirectory($directory)
+    {
+        static::$directory = $directory;
+    }
+
+    /**
      * Get the locale data.
      *
      * @param string $identifier The data identifier
@@ -143,8 +170,8 @@ class Data
             if ($dir === '') {
                 throw new Exception\DataFolderNotFound($locale, static::$fallbackLocale);
             }
-            $file = $dir.DIRECTORY_SEPARATOR.$identifier.'.php';
-            if (!is_file(__DIR__.DIRECTORY_SEPARATOR.$file)) {
+            $file = self::$directory.DIRECTORY_SEPARATOR.$dir.DIRECTORY_SEPARATOR.$identifier.'.php';
+            if (!is_file($file)) {
                 throw new Exception\DataFileNotFound($identifier, $locale, static::$fallbackLocale);
             }
             $data = include $file;
@@ -182,8 +209,8 @@ class Data
         if (!preg_match('/^[a-zA-Z0-9_\\-]+$/', $identifier)) {
             throw new Exception\InvalidDataFile($identifier);
         }
-        $file = 'data'.DIRECTORY_SEPARATOR."$identifier.php";
-        if (!is_file(__DIR__.DIRECTORY_SEPARATOR.$file)) {
+        $file = self::$directory.DIRECTORY_SEPARATOR."$identifier.php";
+        if (!is_file($file)) {
             throw new Exception\DataFileNotFound($identifier);
         }
         $data = include $file;
@@ -208,7 +235,7 @@ class Data
     public static function getAvailableLocales($allowGroups = false)
     {
         $locales = array();
-        $dir = __DIR__.DIRECTORY_SEPARATOR.'data';
+        $dir = self::$directory;
         if (is_dir($dir) && is_readable($dir)) {
             $contents = @scandir($dir);
             if (is_array($contents)) {
@@ -495,9 +522,8 @@ class Data
             $key = $locale.'/'.static::$fallbackLocale;
             if (!isset($cache[$key])) {
                 foreach (static::getLocaleAlternatives($locale) as $alternative) {
-                    $dir = 'data'.DIRECTORY_SEPARATOR.$alternative;
-                    if (is_dir(__DIR__.DIRECTORY_SEPARATOR.$dir)) {
-                        $result = $dir;
+                    if (is_dir(self::$directory.DIRECTORY_SEPARATOR.$alternative)) {
+                        $result = $alternative;
                         break;
                     }
                 }


### PR DESCRIPTION
Allow users to specify a custom data directory rather than hardcoding `punic/src/data`. This allows for instance that you check out the entire `punic-data` and point to the files there.