### PR TITLE
Allow providing custom data overrides

### DIFF
--- a/src/Data.php
+++ b/src/Data.php
@@ -140,6 +140,8 @@ class Data
      * by identifier. If no locale is specified, overrides for all locales are
      * returned index by locale.
      *
+     * @param null|mixed $locale
+     *
      * @return array Associative array
      */
     public static function getOverrides($locale = null)
@@ -148,9 +150,9 @@ class Data
             return static::$overrides;
         } elseif (isset(static::$overrides[$locale])) {
             return static::$overrides[$locale];
-        } else {
-            return array();
         }
+
+        return array();
     }
 
     /**
@@ -158,10 +160,10 @@ class Data
      *
      * Overrides may be provides either one locale at a time or all locales at once.
      *
-     * @param array  $overrides Associative array index by locale (if $locale is null) or identifier.
+     * @param array  $overrides Associative array index by locale (if $locale is null) or identifier
      * @param string $locale
      */
-    public static function setOverrides($overrides, $locale = null)
+    public static function setOverrides(array $overrides, $locale = null)
     {
         static::$cache = array();
 
@@ -186,8 +188,9 @@ class Data
      * Set custom overrides of CLDR locale.
      *
      * @param array Associative array indexed by identifier
+     * @param array $overrides
      */
-    public static function setOverridesGeneric($overrides)
+    public static function setOverridesGeneric(array $overrides)
     {
         static::$cacheGeneric = array();
 
@@ -695,7 +698,7 @@ class Data
         return $result;
     }
 
-    public static function merge(array $data, array $overrides)
+    protected static function merge(array $data, array $overrides)
     {
         foreach ($overrides as $key => $override) {
             if (isset($data[$key])) {
@@ -711,6 +714,7 @@ class Data
                 $data[$key] = $override;
             }
         }
+
         return $data;
     }
 }

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -71,6 +71,13 @@ class Exception extends \Exception
     const VALUE_NOT_IN_LIST = 10008;
 
     /**
+     * Exception code for the \Punic\Exception\InvalidOverride exception.
+     *
+     * @var int
+     */
+    const INVALID_OVERRIDE = 10009;
+
+    /**
      * Initializes the instance.
      *
      * @param string $message The exception message

--- a/src/Exception/InvalidOverride.php
+++ b/src/Exception/InvalidOverride.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Punic\Exception;
+
+/**
+ * An exception raised when an invalid data override is provided.
+ */
+class InvalidOverride extends \Punic\Exception
+{
+    /**
+     * Initializes the instance.
+     *
+     * @param mixed      $data     The data being overridden
+     * @param mixed      $override The override data
+     * @param \Exception $previous The previous exception used for the exception chaining
+     */
+    public function __construct($data, $override, $previous = null)
+    {
+        $message = 'Cannot override '.$this->dataToString($data).' with '.$this->dataToString($override);
+        parent::__construct($message, \Punic\Exception::INVALID_OVERRIDE, $previous);
+    }
+
+    /**
+     * Convert override data to a string.
+     *
+     * @param  mixed $data
+     * @return string
+     */
+    protected function dataToString($data)
+    {
+        if (is_array($data)) {
+            return 'array with keys '.implode(', ', array_keys($data));
+        } else {
+            return gettype($data).' value '.$data;
+        }
+    }
+}

--- a/src/Exception/InvalidOverride.php
+++ b/src/Exception/InvalidOverride.php
@@ -24,14 +24,15 @@ class InvalidOverride extends \Punic\Exception
      * Convert override data to a string.
      *
      * @param  mixed $data
+     *
      * @return string
      */
     protected function dataToString($data)
     {
         if (is_array($data)) {
             return 'array with keys '.implode(', ', array_keys($data));
-        } else {
-            return gettype($data).' value '.$data;
         }
+
+        return gettype($data).' value '.$data;
     }
 }

--- a/tests/Data/DataTest.php
+++ b/tests/Data/DataTest.php
@@ -7,6 +7,12 @@ use Punic\Unit;
 
 class DataTest extends PHPUnit_Framework_TestCase
 {
+    protected function tearDown()
+    {
+        Data::setOverrides(array());
+        Data::setOverridesGeneric(array());
+    }
+
     /**
      * @return array
      */

--- a/tests/Data/DataTest.php
+++ b/tests/Data/DataTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use Punic\Data;
 use Punic\Calendar;
+use Punic\Data;
 use Punic\Territory;
 use Punic\Unit;
 
@@ -247,13 +247,13 @@ class DataTest extends PHPUnit_Framework_TestCase
                         'days' => array(
                             'format' => array(
                                 'wide' => array(
-                                    'mon' => 1
+                                    'mon' => 1,
                                 ),
                             ),
                         ),
-                    )
+                    ),
                 ),
-                'Cannot override string value Monday with integer value 1'
+                'Cannot override string value Monday with integer value 1',
             ),
             array(
                 array(
@@ -261,29 +261,32 @@ class DataTest extends PHPUnit_Framework_TestCase
                         'days' => array(
                             'format' => array(
                                 'wide' => array(
-                                    'mon' => [1, 2, 3]
+                                    'mon' => array(1, 2, 3),
                                 ),
                             ),
                         ),
-                    )
+                    ),
                 ),
-                'Cannot override string value Monday with array with keys 0, 1, 2'
+                'Cannot override string value Monday with array with keys 0, 1, 2',
             ),
             array(
                 array(
                     'calendar' => array(
                         'days' => 'foo',
-                    )
+                    ),
                 ),
-                'Cannot override array with keys format, stand-alone with string value foo'
+                'Cannot override array with keys format, stand-alone with string value foo',
             ),
         );
     }
 
     /**
      * @dataProvider invalidOverridesProvider
+     *
+     * @param array $overrides
+     * @param string $message
      */
-    public function testInvalidOverrides($overrides, $message)
+    public function testInvalidOverrides(array $overrides, $message)
     {
         Data::setOverrides($overrides, 'en');
 


### PR DESCRIPTION
Sometimes you may not be satisfied with a specific translation in the CLDR data for whatever reason.

This PR adds support for providing custom overrides. Overrides may be provided either per locale or all at once.