### PR TITLE
Support codeMappings

### DIFF
--- a/src/Currency.php
+++ b/src/Currency.php
@@ -124,6 +124,54 @@ class Currency
     }
 
     /**
+     * Returns the ISO 4217 code for a currency given its code.
+     *
+     * Historical currencies are not supported.
+     *
+     * @param string $currencyCode The currency code
+     *
+     * @return string Returns the ISO 427 code, or an empty string if $currencyCode is not valid
+     *
+     * @see http://unicode.org/reports/tr35/tr35-info.html#Supplemental_Code_Mapping
+     */
+    public static function getCode($currencyCode)
+    {
+        $codeMappings = Data::getGeneric('codeMappings');
+        $currencies = $codeMappings['currencies'];
+
+        if (isset($currencies[$currencyCode]['numeric'])) {
+            return $currencies[$currencyCode]['numeric'];
+        }
+
+        return '';
+    }
+
+    /**
+     * Returns the currency code given its ISO 4217 code.
+     *
+     * Historical currencies are not supported.
+     *
+     * @param string $code The ISO 427 code
+     *
+     * @return string Returns the currency code, or an empty string if $code is not valid
+     *
+     * @see http://unicode.org/reports/tr35/tr35-info.html#Supplemental_Code_Mapping
+     */
+    public static function getByCode($code)
+    {
+        $codeMappings = Data::getGeneric('codeMappings');
+        $currencies = $codeMappings['currencies'];
+
+        foreach ($currencies as $currencyCode => $currency) {
+            if (isset($currency['numeric']) && $currency['numeric'] == $code) {
+                return $currencyCode;
+            }
+        }
+
+        return '';
+    }
+
+    /**
      * Return the history for the currencies used in a territory.
      *
      * @param string $territoryCode The territoy code

--- a/src/Currency.php
+++ b/src/Currency.php
@@ -124,17 +124,17 @@ class Currency
     }
 
     /**
-     * Returns the ISO 4217 code for a currency given its code.
+     * Returns the ISO 4217 code for a currency given its currency code.
      *
      * Historical currencies are not supported.
      *
-     * @param string $currencyCode The currency code
+     * @param string $currencyCode The 3-letter currency code
      *
-     * @return string Returns the ISO 427 code, or an empty string if $currencyCode is not valid
+     * @return string Returns the numeric ISO 427 code, or an empty string if $currencyCode is not valid
      *
      * @see http://unicode.org/reports/tr35/tr35-info.html#Supplemental_Code_Mapping
      */
-    public static function getCode($currencyCode)
+    public static function getNumericCode($currencyCode)
     {
         $codeMappings = Data::getGeneric('codeMappings');
         $currencies = $codeMappings['currencies'];
@@ -151,13 +151,13 @@ class Currency
      *
      * Historical currencies are not supported.
      *
-     * @param string $code The ISO 427 code
+     * @param string $code The numeric ISO 427 code
      *
-     * @return string Returns the currency code, or an empty string if $code is not valid
+     * @return string Returns the 3-letter currency code, or an empty string if $code is not valid
      *
      * @see http://unicode.org/reports/tr35/tr35-info.html#Supplemental_Code_Mapping
      */
-    public static function getByCode($code)
+    public static function getByNumericCode($code)
     {
         $codeMappings = Data::getGeneric('codeMappings');
         $currencies = $codeMappings['currencies'];

--- a/tests/Currency/CurrencyTest.php
+++ b/tests/Currency/CurrencyTest.php
@@ -23,15 +23,15 @@ class CurrencyTest extends PHPUnit_Framework_TestCase
     public function providerGetInfo()
     {
         return array(
-            array('en', 'USD', null, 'US Dollar', '$', '$', ''),
-            array('it', 'USD', null, 'dollaro statunitense', 'USD', '$', ''),
-            array('en', 'Invalid currency code', null, '', '', '', ''),
-            array('de', 'ARS', null, 'Argentinischer Peso', 'ARS', '$', ''),
-            array('en', 'USD', 0, 'US dollars', '$', '$', ''),
-            array('en', 'USD', 1, 'US dollar', '$', '$', ''),
-            array('en', 'USD', 2, 'US dollars', '$', '$', ''),
-            array('en', 'USD', 'one', 'US dollar', '$', '$', ''),
-            array('en', 'USD', 'many', 'US dollars', '$', '$', ''),
+            array('en', 'USD', null, 'US Dollar', '$', '$', '', 840),
+            array('it', 'USD', null, 'dollaro statunitense', 'USD', '$', '', 840),
+            array('en', 'Invalid currency code', null, '', '', '', '', ''),
+            array('de', 'ARS', null, 'Argentinischer Peso', 'ARS', '$', '', 32),
+            array('en', 'USD', 0, 'US dollars', '$', '$', '', 840),
+            array('en', 'USD', 1, 'US dollar', '$', '$', '', 840),
+            array('en', 'USD', 2, 'US dollars', '$', '$', '', 840),
+            array('en', 'USD', 'one', 'US dollar', '$', '$', '', 840),
+            array('en', 'USD', 'many', 'US dollars', '$', '$', '', 840),
         );
     }
 
@@ -45,13 +45,22 @@ class CurrencyTest extends PHPUnit_Framework_TestCase
      * @param string $currencySymbol
      * @param string $currencySymbolNarrow
      * @param string $currencySymbolAlternative
+     * @param mixed $iso4217
      */
-    public function testGetInfo($locale, $currencyCode, $quantity, $currencyName, $currencySymbol, $currencySymbolNarrow, $currencySymbolAlternative)
+    public function testGetInfo($locale, $currencyCode, $quantity, $currencyName, $currencySymbol, $currencySymbolNarrow, $currencySymbolAlternative, $iso4217)
     {
         $this->assertSame($currencyName, \Punic\Currency::getName($currencyCode, $quantity, $locale), 'Error getting name');
         $this->assertSame($currencySymbol, \Punic\Currency::getSymbol($currencyCode, '', $locale), 'Error getting standard symbol');
         $this->assertSame($currencySymbolNarrow, \Punic\Currency::getSymbol($currencyCode, 'narrow', $locale), 'Error getting narrow symbol');
         $this->assertSame($currencySymbolAlternative, \Punic\Currency::getSymbol($currencyCode, 'alt', $locale), 'Error getting alternative symbol');
+        $this->assertSame($iso4217, \Punic\Currency::getCode($currencyCode), 'Error getting code');
+    }
+
+    public function testGetByCode()
+    {
+        $this->assertSame('DKK', \Punic\Currency::getByCode(208));
+        $this->assertSame('DKK', \Punic\Currency::getByCode('208'));
+        $this->assertSame('', \Punic\Currency::getByCode(666));
     }
 
     /**

--- a/tests/Currency/CurrencyTest.php
+++ b/tests/Currency/CurrencyTest.php
@@ -53,14 +53,14 @@ class CurrencyTest extends PHPUnit_Framework_TestCase
         $this->assertSame($currencySymbol, \Punic\Currency::getSymbol($currencyCode, '', $locale), 'Error getting standard symbol');
         $this->assertSame($currencySymbolNarrow, \Punic\Currency::getSymbol($currencyCode, 'narrow', $locale), 'Error getting narrow symbol');
         $this->assertSame($currencySymbolAlternative, \Punic\Currency::getSymbol($currencyCode, 'alt', $locale), 'Error getting alternative symbol');
-        $this->assertSame($iso4217, \Punic\Currency::getCode($currencyCode), 'Error getting code');
+        $this->assertSame($iso4217, \Punic\Currency::getNumericCode($currencyCode), 'Error getting code');
     }
 
     public function testGetByCode()
     {
-        $this->assertSame('DKK', \Punic\Currency::getByCode(208));
-        $this->assertSame('DKK', \Punic\Currency::getByCode('208'));
-        $this->assertSame('', \Punic\Currency::getByCode(666));
+        $this->assertSame('DKK', \Punic\Currency::getByNumericCode(208));
+        $this->assertSame('DKK', \Punic\Currency::getByNumericCode('208'));
+        $this->assertSame('', \Punic\Currency::getByNumericCode(666));
     }
 
     /**

--- a/tests/Territory/TerritoryTest.php
+++ b/tests/Territory/TerritoryTest.php
@@ -74,7 +74,7 @@ class TerritoryTest extends PHPUnit_Framework_TestCase
 
     public function testGetCodeException()
     {
-        $this->setExpectedException('\\Punic\\Exception\\ValueNotInList');
+        $this->setExpectedException('Punic\\Exception\\ValueNotInList');
         Territory::getCode('DE', 'foo');
     }
 
@@ -117,7 +117,7 @@ class TerritoryTest extends PHPUnit_Framework_TestCase
 
     public function testGetByCodeException()
     {
-        $this->setExpectedException('\\Punic\\Exception\\ValueNotInList');
+        $this->setExpectedException('Punic\\Exception\\ValueNotInList');
         Territory::getByCode('666', 'foo');
     }
 

--- a/tests/Territory/TerritoryTest.php
+++ b/tests/Territory/TerritoryTest.php
@@ -36,6 +36,91 @@ class TerritoryTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    /**
+     * @return array
+     */
+    public function providerGetCode()
+    {
+        return array(
+            array('USA', 'US', 'alpha3'),
+            array('840', 'US', 'numeric'),
+            array('US', 'US', 'fips10'),
+            array('AU', 'AT', 'fips10'),
+            array('DGA', 'DG', 'alpha3'),
+            array('', 'EA', 'alpha3'),
+            array('', 'DG', 'numeric'),
+            array(array('US'), 'US', 'internet'),
+            array(array('UK', 'GB'), 'GB', 'internet'),
+            array('', 'FOO', 'alpha3'),
+        );
+    }
+
+    /**
+     * test getCode.
+     *
+     * @dataProvider providerGetCode
+     *
+     * @param string $result
+     * @param string $territoryCode
+     * @param string $type
+     */
+    public function testGetCode($result, $territoryCode, $type)
+    {
+        $this->assertSame(
+            $result,
+            Territory::getCode($territoryCode, $type)
+        );
+    }
+
+    public function testGetCodeException()
+    {
+        $this->setExpectedException('\\Punic\\Exception\\ValueNotInList');
+        Territory::getCode('DE', 'foo');
+    }
+
+    /**
+     * @return array
+     */
+    public function providerGetByCode()
+    {
+        return array(
+            array('US', 'USA', 'alpha3'),
+            array('US', '840', 'numeric'),
+            array('US', 840, 'numeric'),
+            array('US', 'US', 'fips10'),
+            array('AT', 'AU', 'fips10'),
+            array('DG', 'DGA', 'alpha3'),
+            array('US', 'US', 'internet'),
+            array('GB', 'UK', 'internet'),
+            array('GB', 'GB', 'internet'),
+            array('ZZ', 'COM', 'internet'),
+        );
+    }
+
+    /**
+     * test getByCode.
+     *
+     * @dataProvider providerGetByCode
+     *
+     * @param string $result
+     * @param string $territoryCode
+     * @param string $type
+     * @param mixed $code
+     */
+    public function testGetByCode($result, $code, $type)
+    {
+        $this->assertSame(
+            $result,
+            Territory::getByCode($code, $type)
+        );
+    }
+
+    public function testGetByCodeException()
+    {
+        $this->setExpectedException('\\Punic\\Exception\\ValueNotInList');
+        Territory::getByCode('666', 'foo');
+    }
+
     public function testCountries()
     {
         $countries = Territory::getCountries();


### PR DESCRIPTION
Add methods for accessing alternative codes for currencies and territories:

* Punic\Currency::getCode($code)
* Punic\Currency::getByCode($code)
* Punic\Territory::getCode($code, $type)
* Punic\Territory::getByCode($code, $type)

Requires https://github.com/punic/data/pull/5.

http://unicode.org/reports/tr35/tr35-info.html#Supplemental_Code_Mapping
https://www.unicode.org/repos/cldr/trunk/common/supplemental/supplementalData.xml