### PR TITLE
Fix mix-up of m (minutes) with (M) months

### DIFF
--- a/src/Calendar.php
+++ b/src/Calendar.php
@@ -2264,7 +2264,7 @@ class Calendar
             $adjustedGreatestDifference = 'h';
         } elseif ($adjustedGreatestDifference === 'Q' && strpos($skeleton, 'Q') === false) {
             // Ignore quarter, if it is not part of the skeleton.
-            $adjustedGreatestDifference = 'm';
+            $adjustedGreatestDifference = 'M';
         } elseif ($adjustedGreatestDifference[0] === 'S') {
             $skeletonGranularityIndex += substr_count($skeleton, 'S') - 1;
         }

--- a/tests/Calendar/CalendarTest.php
+++ b/tests/Calendar/CalendarTest.php
@@ -1325,6 +1325,10 @@ class CalendarTest extends PHPUnit_Framework_TestCase
         );
         $this->assertSame(
             array('MMMM d – MMMM d, y', true),
+            Calendar::getIntervalFormat('yMMMMd', 'Q')
+        );
+        $this->assertSame(
+            array('MMMM d – MMMM d, y', true),
             Calendar::getIntervalFormat('yMMMMd', 'M')
         );
         $this->assertSame(


### PR DESCRIPTION
It seems I confused `m` (minutes) with `M` (months) in `Calendar::adjustGreatestDifference()`.

This problem is visible when calling `formatInterval()` with two dates in the same year but in different quarters. This makes the formatting fall back to combining two complete formatted dates using the `intervalFormatFallback` pattern, i.e. instead of the intended `June 30 – July 1, 2018`, the actual output is `June 30, 2018 – July 1, 2018`.