### PR TITLE
Tests with custom dir

### DIFF
--- a/tests/Data/DataTest.php
+++ b/tests/Data/DataTest.php
@@ -123,7 +123,7 @@ class DataTest extends TestCase
     {
         $locales = Data::getAvailableLocales();
         // this list isn't static, we assume that something between 1 and 320 locales is okay
-        $this->assertLessThan(2000, count($locales));
+        $this->assertLessThan(4000, count($locales));
         $this->assertGreaterThan(1, count($locales));
     }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -22,3 +22,11 @@ spl_autoload_register(
 );
 
 require_once dirname(__DIR__).'/punic.php';
+$dataDir = (string) getenv('PUNIC_TEST_DATADIR');
+if ($dataDir !== '') {
+    if (!is_dir($dataDir)) {
+        throw new Exception("The PUNIC_TEST_DATADIR environment variable points to a non existing directory ({$dataDir}).");
+    }
+    Punic\Data::setDataDirectory($dataDir);
+}
+unset($dataDir);


### PR DESCRIPTION
It may be useful to run tests using a custom data dir generated by [punic/data](https://github.com/punic/data).