### PR TITLE
Fix spellout when working with big numbers

### DIFF
--- a/src/Number.php
+++ b/src/Number.php
@@ -410,9 +410,9 @@ class Number
 
             // Add .5 to avoid floating-point rounding error in PHP 5. $base is
             // an integer, so adding a number < 1 will not break anything.
-            $divisor = pow($radix, (int) log($base + .5, $radix));
+            $divisor = pow($radix, floor(abs(log($base + .5, $radix))));
 
-            $right = $value % $divisor;
+            $right = fmod($value, $divisor);
             $left = floor($value / $divisor);
 
             if ($right) {

--- a/src/Number.php
+++ b/src/Number.php
@@ -312,7 +312,7 @@ class Number
     {
         $data = Data::get('rbnf', $locale);
         if (!isset($data[$type])) {
-            $data += Data::get('rbnf', 'root');
+            $data += Data::get('rbnf', 'root', true);
         }
         if (!isset($data[$type])) {
             throw new Exception\ValueNotInList($type, array_keys($data));


### PR DESCRIPTION
Let's switch from integers to floats when spelling out numbers, otherwise we risk to break stuff when processing numbers greater than 2,147,483,647 (for 32-bit systems) or 9,223,372,036,854,775,807 (for 64-bit systems).

This shouldn't solve all the spellout problems for the 32-bit systems: another pull request will fix them.