### PR TITLE
Add formatDateTime test for UTC

### DIFF
--- a/tests/Calendar/CalendarTest.php
+++ b/tests/Calendar/CalendarTest.php
@@ -1705,6 +1705,10 @@ class CalendarTest extends TestCase
             'Ieri 14:15',
             Calendar::formatDateTime($yesterday, 'full|short^|short', 'it')
         );
+        $this->assertSame(
+            'October 12, 2010 at 11:59:00 PM UTC',
+            Calendar::formatDateTime(Calendar::toDateTime('2010-10-12 23:59 UTC'), 'long')
+        );
     }
 
     public function testFormatDateTimeEx()


### PR DESCRIPTION
In punic 3.1.0 this would return:
```
Calendar::formatDateTime(Calendar::toDateTime('2010-10-12 23:59 UTC'), 'long')
October 12, 2010 at 11:59:00 PM GMT+0
```
In punic 3.2.0 it returns:
```
October 12, 2010 at 11:59:00 PM UTC
```
which actually is better.

A ``git bisect`` shows that the change in behavior happened in PR #140 

Prior to that PR, the test added here fails, since that PR it passes.

I noticed this small (and good) behaviour change in https://github.com/owncloud/core/pull/33461