### PR TITLE
Avoid creating dynamic property, fix PHP 8.2 warning

### DIFF
--- a/bin/punic-data
+++ b/bin/punic-data
@@ -549,6 +549,11 @@ class SourceData
     protected $cldrVersion;
 
     /**
+     * @var string|null
+     */
+    protected $formatVersion;
+
+    /**
      * @var string[]|null
      */
     protected $availableLocales;


### PR DESCRIPTION
This PR ensures that the `$formatVersion` property of the `SourceData` class is predefined, to avoid triggering a deprecation warning when updating punic locales with PHP 8.2

```
Creation of dynamic property SourceData::$formatVersion is deprecated in /Users/ragulka/sites/example/vendor/punic/punic/bin/punic-data @ line 660
FILE: /Users/ragulka/sites/example/vendor/punic/punic/bin/punic-data@996
TRACE:
#0 /Users/ragulka/sites/example/vendor/punic/punic/bin/punic-data(660): handleError(8192, 'Creation of dyn...', '/Users/ragulka/...', 660)
#1 /Users/ragulka/sites/example/vendor/punic/punic/bin/punic-data(1024): SourceData->setCLDRVersion('42')
#2 /Users/ragulka/sites/example/vendor/bin/punic-data(120): include('/Users/ragulka/...')
#3 {main}
```